### PR TITLE
Update saxpy and sgemm examples to move the vsetvli into the loop bod…

### DIFF
--- a/rvv_saxpy.c
+++ b/rvv_saxpy.c
@@ -54,7 +54,8 @@ void saxpy_vec(size_t n, const float a, const float *x, float *y) {
 
   vfloat32m8_t vx, vy;
 
-  for (; (l = vsetvl_e32m8(n)) > 0; n -= l) {
+  for (; n > 0; n -= l) {
+    l = vsetvl_e32m8(n);
     vx = vle32_v_f32m8(x, l);
     x += l;
     vy = vle32_v_f32m8(y, l);

--- a/rvv_sgemm.c
+++ b/rvv_sgemm.c
@@ -68,10 +68,11 @@ void sgemm_vec(size_t size_m, size_t size_n, size_t size_k,
                float *c, // m * n matrix
                size_t ldc) {
   size_t vl;
-  for (int m = 0; m < size_m; ++m) {
+  for (size_t m = 0; m < size_m; ++m) {
     const float *b_n_ptr = b;
     float *c_n_ptr = c;
-    for (int c_n_count = size_n; (vl = vsetvl_e32m1(c_n_count )); c_n_count -= vl) {
+    for (size_t c_n_count = size_n; c_n_count; c_n_count -= vl) {
+      vl = vsetvl_e32m1(c_n_count );
       const float *a_k_ptr = a;
       const float *b_k_ptr = b_n_ptr;
       vfloat32m1_t acc = vle32_v_f32m1(c_n_ptr, vl);


### PR DESCRIPTION
…y and not make the loop condition depend on it.

vsetvl only returns 0 if the input is 0 so there's no need to test
for 0 after the vsetvl. It does add more lines to C code, but generates
shorter and probably faster assembly.

I also replaced some ints with size_t to avoid sext.w in the generated assembly.