### PR TITLE
Revise zvfofp8min interface

### DIFF
--- a/auto-generated/api-testing/vfncvt.c
+++ b/auto-generated/api-testing/vfncvt.c
@@ -1015,362 +1015,374 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfncvt_f_f_w_f32m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/api-testing/vfncvtbf16.c
+++ b/auto-generated/api-testing/vfncvtbf16.c
@@ -1,526 +1,552 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m4_t
+test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m4_t
+test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }

--- a/auto-generated/api-testing/vfwcvtbf16.c
+++ b/auto-generated/api-testing/vfwcvtbf16.c
@@ -1,114 +1,134 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                 size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e4m3mf8_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e4m3mf4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
+                                                   vfloat8e4m3mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e4m3m4_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                 size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e5m2mf8_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e5m2mf4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
+                                                   vfloat8e5m2mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e5m2m4_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vm, vs2, vl);
 }

--- a/auto-generated/gnu-api-tests/vfncvt.c
+++ b/auto-generated/gnu-api-tests/vfncvt.c
@@ -915,323 +915,323 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2, size_t 
   return __riscv_vfncvt_f_f_w_f32m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvt\.[ivxfswum.]+\s+} 308 } } */

--- a/auto-generated/gnu-api-tests/vfncvtbf16.c
+++ b/auto-generated/gnu-api-tests/vfncvtbf16.c
@@ -3,387 +3,387 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvtbf16\.[ivxfswum.]+\s+} 96 } } */

--- a/auto-generated/gnu-api-tests/vfwcvtbf16.c
+++ b/auto-generated/gnu-api-tests/vfwcvtbf16.c
@@ -3,99 +3,99 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm, vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vm, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm, vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vm, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm, vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm, vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vm, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm, vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vm, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm, vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwcvtbf16\.[ivxfswum.]+\s+} 24 } } */

--- a/auto-generated/gnu-overloaded-tests/vfncvt.c
+++ b/auto-generated/gnu-overloaded-tests/vfncvt.c
@@ -915,323 +915,323 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2, size_t 
   return __riscv_vfncvt_f(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvt\.[ivxfswum.]+\s+} 308 } } */

--- a/auto-generated/gnu-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/gnu-overloaded-tests/vfncvtbf16.c
@@ -3,387 +3,387 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvtbf16\.[ivxfswum.]+\s+} 96 } } */

--- a/auto-generated/gnu-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/gnu-overloaded-tests/vfwcvtbf16.c
@@ -3,99 +3,99 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm, vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm, vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm, vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm, vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm, vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm, vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwcvtbf16\.[ivxfswum.]+\s+} 24 } } */

--- a/auto-generated/intrinsic_funcs.adoc
+++ b/auto-generated/intrinsic_funcs.adoc
@@ -53118,30 +53118,37 @@ vuint32m8_t __riscv_vdot4au_vx_u32m8_m(vbool4_t vm, vuint32m8_t vd,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2,
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
                                                       size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2,
+vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
                                                       size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                   size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                   size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                   size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
-                                                     vuint8m1_t vs2, size_t vl);
+                                                     vfloat8e4m3m1_t vs2,
+                                                     size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
-                                                     vuint8m2_t vs2, size_t vl);
+                                                     vfloat8e4m3m2_t vs2,
+                                                     size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
-                                                     vuint8m4_t vs2, size_t vl);
+                                                     vfloat8e4m3m4_t vs2,
+                                                     size_t vl);
 ----
 
 [[ofp8-e5m2-to-bf16-conversion-instructions]]
@@ -53149,30 +53156,37 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2,
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
                                                       size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2,
+vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
                                                       size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                   size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                   size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                   size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
-                                                     vuint8m1_t vs2, size_t vl);
+                                                     vfloat8e5m2m1_t vs2,
+                                                     size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
-                                                     vuint8m2_t vs2, size_t vl);
+                                                     vfloat8e5m2m2_t vs2,
+                                                     size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
-                                                     vuint8m4_t vs2, size_t vl);
+                                                     vfloat8e5m2m4_t vs2,
+                                                     size_t vl);
 ----
 
 === Zvfofp8min - BF16 to OFP8 conversion instructions
@@ -53182,142 +53196,147 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                   size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
-                                                    size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                        vbfloat16mf4_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                            vbfloat16mf4_t vs2,
-                                                            unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                        vbfloat16mf2_t vs2,
-                                                        unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                            vbfloat16mf2_t vs2,
-                                                            unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                       vbfloat16m1_t vs2,
-                                                       unsigned int frm,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                           vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                         size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                     vbfloat16m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                         vbfloat16m2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                     vbfloat16m4_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                         vbfloat16m4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                     vbfloat16m8_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                         vbfloat16m8_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                             vbfloat16mf4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(
+    vbool64_t vm, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                             vbfloat16mf2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(
+    vbool32_t vm, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                            vbfloat16m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                          vbfloat16m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                              vbfloat16m2_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                          vbfloat16m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                              vbfloat16m4_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                          vbfloat16m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                              vbfloat16m8_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
 ----
 
 [[bf16-to-ofp8-e5m2-conversion-instructions]]
@@ -53325,142 +53344,147 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                   size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
-                                                    size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                        vbfloat16mf4_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                            vbfloat16mf4_t vs2,
-                                                            unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                        vbfloat16mf2_t vs2,
-                                                        unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                            vbfloat16mf2_t vs2,
-                                                            unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                       vbfloat16m1_t vs2,
-                                                       unsigned int frm,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                           vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                         size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                     vbfloat16m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                         vbfloat16m2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                     vbfloat16m4_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                         vbfloat16m4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                     vbfloat16m8_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                         vbfloat16m8_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                             vbfloat16mf4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(
+    vbool64_t vm, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                             vbfloat16mf2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(
+    vbool32_t vm, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                            vbfloat16m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                          vbfloat16m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                              vbfloat16m2_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                          vbfloat16m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                              vbfloat16m4_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                          vbfloat16m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                              vbfloat16m8_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
 ----
 
 === Zvfofp8min - FP32 to OFP8 conversion instructions
@@ -53470,84 +53494,105 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2,
+                                                    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2,
+                                                    size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2,
+                                                    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                    vfloat32mf2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                    vfloat32m1_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vfloat32m2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                     vfloat32mf2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                         vfloat32mf2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                     vfloat32m1_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                         vfloat32m1_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                     vfloat32m2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vfloat32m2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm,
+                                                   vfloat32m4_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vfloat32m4_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm,
+                                                   vfloat32m8_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vfloat32m8_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
 ----
 
 [[fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -53555,84 +53600,105 @@ vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2,
+                                                    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2,
+                                                    size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2,
+                                                    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                    vfloat32mf2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                    vfloat32m1_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vfloat32m2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                     vfloat32mf2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                         vfloat32mf2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                     vfloat32m1_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                         vfloat32m1_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                     vfloat32m2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vfloat32m2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm,
+                                                   vfloat32m4_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vfloat32m4_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm,
+                                                   vfloat32m8_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vfloat32m8_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
 ----
 
 === Zvabd - Vector Absolute Difference instructions

--- a/auto-generated/intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
@@ -6,30 +6,37 @@
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2,
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
                                                       size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2,
+vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
                                                       size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                   size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                   size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                   size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
-                                                     vuint8m1_t vs2, size_t vl);
+                                                     vfloat8e4m3m1_t vs2,
+                                                     size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
-                                                     vuint8m2_t vs2, size_t vl);
+                                                     vfloat8e4m3m2_t vs2,
+                                                     size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
-                                                     vuint8m4_t vs2, size_t vl);
+                                                     vfloat8e4m3m4_t vs2,
+                                                     size_t vl);
 ----
 
 [[ofp8-e5m2-to-bf16-conversion-instructions]]
@@ -37,28 +44,35 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2,
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
                                                       size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2,
+vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
                                                       size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                   size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                   size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                   size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
-                                                     vuint8m1_t vs2, size_t vl);
+                                                     vfloat8e5m2m1_t vs2,
+                                                     size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
-                                                     vuint8m2_t vs2, size_t vl);
+                                                     vfloat8e5m2m2_t vs2,
+                                                     size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
-                                                     vuint8m4_t vs2, size_t vl);
+                                                     vfloat8e5m2m4_t vs2,
+                                                     size_t vl);
 ----

--- a/auto-generated/intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
@@ -6,142 +6,147 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                   size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
-                                                    size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                        vbfloat16mf4_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                            vbfloat16mf4_t vs2,
-                                                            unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                        vbfloat16mf2_t vs2,
-                                                        unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                            vbfloat16mf2_t vs2,
-                                                            unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                       vbfloat16m1_t vs2,
-                                                       unsigned int frm,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                           vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                         size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                     vbfloat16m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                         vbfloat16m2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                     vbfloat16m4_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                         vbfloat16m4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                     vbfloat16m8_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                         vbfloat16m8_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                             vbfloat16mf4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(
+    vbool64_t vm, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                             vbfloat16mf2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(
+    vbool32_t vm, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                            vbfloat16m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                          vbfloat16m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                              vbfloat16m2_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                          vbfloat16m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                              vbfloat16m4_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                          vbfloat16m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                              vbfloat16m8_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
 ----
 
 [[bf16-to-ofp8-e5m2-conversion-instructions]]
@@ -149,140 +154,145 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                   size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
-                                                    size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                       unsigned int frm,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                        vbfloat16mf4_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                            vbfloat16mf4_t vs2,
-                                                            unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                        vbfloat16mf2_t vs2,
-                                                        unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                            vbfloat16mf2_t vs2,
-                                                            unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                       vbfloat16m1_t vs2,
-                                                       unsigned int frm,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                           vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                         size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                     vbfloat16m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                         vbfloat16m2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                     vbfloat16m4_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                         vbfloat16m4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                     vbfloat16m8_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                         vbfloat16m8_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                             vbfloat16mf4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(
+    vbool64_t vm, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                             vbfloat16mf2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(
+    vbool32_t vm, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                            vbfloat16m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm, vbfloat16m1_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                          vbfloat16m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                              vbfloat16m2_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                          vbfloat16m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                              vbfloat16m4_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                          vbfloat16m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                              vbfloat16m8_t vs2,
+                                                              unsigned int frm,
+                                                              size_t vl);
 ----

--- a/auto-generated/intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
@@ -6,84 +6,105 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2,
+                                                    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2,
+                                                    size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2,
+                                                    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                    vfloat32mf2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                    vfloat32m1_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vfloat32m2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                     vfloat32mf2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                         vfloat32mf2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                     vfloat32m1_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                         vfloat32m1_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                     vfloat32m2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vfloat32m2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm,
+                                                   vfloat32m4_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vfloat32m4_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm,
+                                                   vfloat32m8_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vfloat32m8_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
 ----
 
 [[fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -91,82 +112,103 @@ vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2,
+                                                    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2,
+                                                    size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2,
+                                                    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, unsigned int frm,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                    vfloat32mf2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                    vfloat32m1_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vfloat32m2_t vs2,
-                                                    unsigned int frm,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                     vfloat32mf2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                         vfloat32mf2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                     vfloat32m1_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                         vfloat32m1_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                     vfloat32m2_t vs2,
+                                                     unsigned int frm,
+                                                     size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vfloat32m2_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm,
+                                                   vfloat32m4_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vfloat32m4_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm,
+                                                   vfloat32m8_t vs2,
+                                                   unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vfloat32m8_t vs2,
+                                                       unsigned int frm,
+                                                       size_t vl);
 ----

--- a/auto-generated/llvm-api-tests/vfncvt.c
+++ b/auto-generated/llvm-api-tests/vfncvt.c
@@ -1021,362 +1021,374 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfncvt_f_f_w_f32m4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/llvm-api-tests/vfncvtbf16.c
@@ -7,526 +7,552 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3m4_t
+test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vm, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m4_t
+test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vm, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vm, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vm, vs2, __RISCV_FRM_RNE,
                                                        vl);
 }

--- a/auto-generated/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/llvm-api-tests/vfwcvtbf16.c
@@ -7,114 +7,134 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                 size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e4m3mf8_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e4m3mf4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
+                                                   vfloat8e4m3mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e4m3m4_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                 size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e5m2mf8_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e5m2mf4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
+                                                   vfloat8e5m2mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e5m2m4_t vs2,
                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vm, vs2, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vfncvt.c
+++ b/auto-generated/llvm-overloaded-tests/vfncvt.c
@@ -1021,362 +1021,374 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfncvt_f(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
                                              size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/llvm-overloaded-tests/vfncvtbf16.c
@@ -7,498 +7,524 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t
+test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
+vfloat8e4m3m2_t
+test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m4_t
+test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t
+test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t
+test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m4_t
+test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/llvm-overloaded-tests/vfwcvtbf16.c
@@ -7,114 +7,134 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e4m3mf8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e4m3mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+                                                   vfloat8e4m3mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e4m3m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e5m2mf8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e5m2mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+                                                   vfloat8e5m2mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e5m2m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfncvt.c
+++ b/auto-generated/overloaded-api-testing/vfncvt.c
@@ -1015,362 +1015,374 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_m(vbool8_t vm, vfloat64m8_t vs2,
   return __riscv_vfncvt_f(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_q_f8e4m3mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_q_f8e4m3mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_q_f8e4m3mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_q_f8e4m3m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_q_f8e4m3m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8(vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4(vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2(vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1(vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2(vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_q_f8e5m2mf8_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_q_f8e5m2mf4_m(vbool32_t vm, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                          size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
+                                               size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_q_f8e5m2mf2_m(vbool16_t vm, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                        size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
                                              size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm(vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm(vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm(vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm(vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm(vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm, vfloat32m1_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                             size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm, vfloat32m2_t vs2,
-                                                 size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_q_f8e5m2m1_rm_m(vbool8_t vm, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                           size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
+                                                size_t vl) {
   return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2,
-                                               size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_q_f8e5m2m2_rm_m(vbool4_t vm, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfncvtbf16.c
+++ b/auto-generated/overloaded-api-testing/vfncvtbf16.c
@@ -1,498 +1,524 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4(vbfloat16mf2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2(vbfloat16m1_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1(vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2(vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4(vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                  vbfloat16mf4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                  vbfloat16mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                 vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t
+test_vfncvt_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
-                                                        vbfloat16m1_t vs2,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                  vbfloat16m2_t vs2,
+vfloat8e4m3m2_t
+test_vfncvt_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m4_t
+test_vfncvt_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4(vbfloat16mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2(vbfloat16m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
-                                                      vbfloat16m2_t vs2,
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1(vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                  vbfloat16m4_t vs2,
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
-                                                      vbfloat16m4_t vs2,
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2(vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                  vbfloat16m8_t vs2,
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2(vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
-                                                      vbfloat16m8_t vs2,
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4(vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                       vbfloat16mf4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_m(vbool64_t vm,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                       vbfloat16mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_m(vbool32_t vm,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                      vbfloat16m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_m(vbool16_t vm,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t
+test_vfncvt_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_m(vbool8_t vm,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t
+test_vfncvt_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_m(vbool4_t vm,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m4_t
+test_vfncvt_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_m(vbool2_t vm,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm(vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm(vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm(vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm(vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm(vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm(vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_m(vbool64_t vm, vbfloat16mf4_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_m(vbool32_t vm, vbfloat16mf2_t vs2,
+                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_m(vbool16_t vm,
+                                                             vbfloat16m1_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_m(vbool8_t vm,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_m(vbool4_t vm,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_m(vbool2_t vm,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2(vm, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/overloaded-api-testing/vfwcvtbf16.c
+++ b/auto-generated/overloaded-api-testing/vfwcvtbf16.c
@@ -1,114 +1,134 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2(vfloat8e4m3mf4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1(vfloat8e4m3mf2_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2(vfloat8e4m3m1_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4(vfloat8e4m3m2_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8(vfloat8e4m3m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e4m3mf8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e4m3mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+                                                   vfloat8e4m3mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e4m3m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2(vfloat8e5m2mf4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1(vfloat8e5m2mf2_t vs2,
+                                                 size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2(vfloat8e5m2m1_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4(vfloat8e5m2m2_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8(vfloat8e5m2m4_t vs2,
+                                                size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_m(vbool64_t vm,
-                                                     vuint8mf8_t vs2,
+                                                     vfloat8e5m2mf8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_m(vbool32_t vm,
-                                                     vuint8mf4_t vs2,
+                                                     vfloat8e5m2mf4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_m(vbool16_t vm,
-                                                   vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+                                                   vfloat8e5m2mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm, vuint8m1_t vs2,
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_m(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm, vuint8m2_t vs2,
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_m(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm, vuint8m4_t vs2,
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_m(vbool2_t vm,
+                                                  vfloat8e5m2m4_t vs2,
                                                   size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16(vm, vs2, vl);
+  return __riscv_vfwcvt_f_bf16(vm, vs2, vl);
 }

--- a/auto-generated/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs.adoc
@@ -41737,25 +41737,25 @@ vuint32m8_t __riscv_vdot4au(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool64_t vm, vuint8mf8_t vs2,
-                                            size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool32_t vm, vuint8mf4_t vs2,
-                                            size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool16_t vm, vuint8mf2_t vs2,
-                                           size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool8_t vm, vuint8m1_t vs2,
-                                           size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool4_t vm, vuint8m2_t vs2,
-                                           size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool2_t vm, vuint8m4_t vs2,
-                                           size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vbool64_t vm, vfloat8e4m3mf8_t vs2,
+                                     size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vbool32_t vm, vfloat8e4m3mf4_t vs2,
+                                     size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vbool16_t vm, vfloat8e4m3mf2_t vs2,
+                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vbool8_t vm, vfloat8e4m3m1_t vs2,
+                                    size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vbool4_t vm, vfloat8e4m3m2_t vs2,
+                                    size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vbool2_t vm, vfloat8e4m3m4_t vs2,
+                                    size_t vl);
 ----
 
 [[overloaded-ofp8-e5m2-to-bf16-conversion-instructions]]
@@ -41763,25 +41763,25 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool2_t vm, vuint8m4_t vs2,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool64_t vm, vuint8mf8_t vs2,
-                                            size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool32_t vm, vuint8mf4_t vs2,
-                                            size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool16_t vm, vuint8mf2_t vs2,
-                                           size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool8_t vm, vuint8m1_t vs2,
-                                           size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool4_t vm, vuint8m2_t vs2,
-                                           size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool2_t vm, vuint8m4_t vs2,
-                                           size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vbool64_t vm, vfloat8e5m2mf8_t vs2,
+                                     size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vbool32_t vm, vfloat8e5m2mf4_t vs2,
+                                     size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vbool16_t vm, vfloat8e5m2mf2_t vs2,
+                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vbool8_t vm, vfloat8e5m2m1_t vs2,
+                                    size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vbool4_t vm, vfloat8e5m2m2_t vs2,
+                                    size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vbool2_t vm, vfloat8e5m2m4_t vs2,
+                                    size_t vl);
 ----
 
 === Zvfofp8min - BF16 to OFP8 conversion instructions
@@ -41791,91 +41791,91 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool2_t vm, vuint8m4_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf4_t vs2, unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf4_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf2_t vs2, unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m1_t vs2, unsigned int frm,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 ----
 
@@ -41884,91 +41884,91 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf4_t vs2, unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf4_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf2_t vs2, unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m1_t vs2, unsigned int frm,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 ----
 
@@ -41979,73 +41979,78 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
+                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
+                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
+                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
+                                            unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
-                                        unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                       unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
+                                            unsigned int frm, size_t vl);
 ----
 
 [[overloaded-fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -42053,73 +42058,78 @@ vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
+                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
+                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
+                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
+                                            unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
-                                        unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                       unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
+                                            unsigned int frm, size_t vl);
 ----
 
 === Zvabd - Vector Absolute Difference instructions

--- a/auto-generated/overloaded_intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
@@ -6,25 +6,25 @@
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool64_t vm, vuint8mf8_t vs2,
-                                            size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool32_t vm, vuint8mf4_t vs2,
-                                            size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool16_t vm, vuint8mf2_t vs2,
-                                           size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool8_t vm, vuint8m1_t vs2,
-                                           size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool4_t vm, vuint8m2_t vs2,
-                                           size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool2_t vm, vuint8m4_t vs2,
-                                           size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vbool64_t vm, vfloat8e4m3mf8_t vs2,
+                                     size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vbool32_t vm, vfloat8e4m3mf4_t vs2,
+                                     size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vbool16_t vm, vfloat8e4m3mf2_t vs2,
+                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vbool8_t vm, vfloat8e4m3m1_t vs2,
+                                    size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vbool4_t vm, vfloat8e4m3m2_t vs2,
+                                    size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vbool2_t vm, vfloat8e4m3m4_t vs2,
+                                    size_t vl);
 ----
 
 [[overloaded-ofp8-e5m2-to-bf16-conversion-instructions]]
@@ -32,23 +32,23 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16(vbool2_t vm, vuint8m4_t vs2,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16(vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool64_t vm, vuint8mf8_t vs2,
-                                            size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool32_t vm, vuint8mf4_t vs2,
-                                            size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool16_t vm, vuint8mf2_t vs2,
-                                           size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool8_t vm, vuint8m1_t vs2,
-                                           size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool4_t vm, vuint8m2_t vs2,
-                                           size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16(vbool2_t vm, vuint8m4_t vs2,
-                                           size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vbool64_t vm, vfloat8e5m2mf8_t vs2,
+                                     size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16(vbool32_t vm, vfloat8e5m2mf4_t vs2,
+                                     size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16(vbool16_t vm, vfloat8e5m2mf2_t vs2,
+                                    size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16(vbool8_t vm, vfloat8e5m2m1_t vs2,
+                                    size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16(vbool4_t vm, vfloat8e5m2m2_t vs2,
+                                    size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16(vbool2_t vm, vfloat8e5m2m4_t vs2,
+                                    size_t vl);
 ----

--- a/auto-generated/overloaded_intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
@@ -6,91 +6,91 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf4_t vs2, unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf4_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16mf2_t vs2, unsigned int frm,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m1_t vs2, unsigned int frm,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vbfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vbfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 ----
 
@@ -99,90 +99,90 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3(vbool2_t vm, vbfloat16m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                             size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf4_t vs2, unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf4_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16mf2_t vs2, unsigned int frm,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf2_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m1_t vs2, unsigned int frm,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m1_t vs2, unsigned int frm,
                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                          unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vbfloat16m2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vbfloat16m4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2(vbool2_t vm, vbfloat16m8_t vs2,
                                             unsigned int frm, size_t vl);
 ----

--- a/auto-generated/overloaded_intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/overloaded_intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
@@ -6,73 +6,78 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
+                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
+                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vfloat32m8_t vs2, unsigned int frm,
+                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbool64_t vm, vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
+                                            unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3(vbool16_t vm, vfloat32m2_t vs2,
-                                        unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3(vbool8_t vm, vfloat32m4_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
-                                       unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
+                                            unsigned int frm, size_t vl);
 ----
 
 [[overloaded-fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -80,71 +85,76 @@ vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3(vbool4_t vm, vfloat32m8_t vs2,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
+                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
+                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
+                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
-                                    size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
-                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vfloat32m8_t vs2, unsigned int frm,
+                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbool64_t vm, vfloat32mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                         unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2(vbool32_t vm, vfloat32m1_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
+                                            unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
                                         unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
-                                    unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2(vbool16_t vm, vfloat32m2_t vs2,
-                                        unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2(vbool8_t vm, vfloat32m4_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
-                                       unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2(vbool4_t vm, vfloat32m8_t vs2,
+                                            unsigned int frm, size_t vl);
 ----

--- a/auto-generated/policy_funcs/api-testing/vfncvt.c
+++ b/auto-generated/policy_funcs/api-testing/vfncvt.c
@@ -2278,870 +2278,1058 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfncvt_f_f_w_f32m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vfloat32mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vfloat32m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vfloat32m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vfloat32mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vfloat32m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vfloat32m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/api-testing/vfncvtbf16.c
@@ -1,1320 +1,1346 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                      vfloat8e4m3m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                       vfloat8e4m3m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                     vfloat8e4m3m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
-                                                            vbfloat16mf4_t vs2,
-                                                            size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
-                                                            vbfloat16mf2_t vs2,
-                                                            size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
-                                                           vbfloat16m1_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
-                                                         vbfloat16m2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
-                                                         vbfloat16m4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
-                                                         vbfloat16m8_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                      vfloat8e5m2m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                       vfloat8e5m2m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                     vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
-                                                            vbfloat16mf4_t vs2,
-                                                            size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
-                                                            vbfloat16mf2_t vs2,
-                                                            size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
-                                                           vbfloat16m1_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
-                                                         vbfloat16m2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
-                                                         vbfloat16m4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
-                                                         vbfloat16m8_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/api-testing/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/api-testing/vfwcvtbf16.c
@@ -2,307 +2,325 @@
 #include <stdint.h>
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e4m3mf8_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e4m3mf4_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e4m3mf2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
+                                                    vfloat8e4m3m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
+                                                    vfloat8e4m3m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
+                                                    vfloat8e4m3m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e4m3m1_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e4m3m2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e4m3m4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e5m2mf8_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e5m2mf4_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e5m2mf2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
+                                                    vfloat8e5m2m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
+                                                    vfloat8e5m2m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
+                                                    vfloat8e5m2m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e5m2m1_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e5m2m2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e5m2m4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vm, vd, vs2, vl);
 }

--- a/auto-generated/policy_funcs/gnu-api-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfncvt.c
@@ -1827,643 +1827,643 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat6
   return __riscv_vfncvt_f_f_w_f32m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvt\.[ivxfswum.]+\s+} 616 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfncvtbf16.c
@@ -3,771 +3,771 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvtbf16\.[ivxfswum.]+\s+} 192 } } */

--- a/auto-generated/policy_funcs/gnu-api-tests/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/gnu-api-tests/vfwcvtbf16.c
@@ -3,195 +3,195 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vm, vd, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwcvtbf16\.[ivxfswum.]+\s+} 48 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfncvt.c
@@ -1827,643 +1827,643 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd, vfloat6
   return __riscv_vfncvt_f_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvt\.[ivxfswum.]+\s+} 616 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfncvtbf16.c
@@ -3,771 +3,771 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfncvtbf16\.[ivxfswum.]+\s+} 192 } } */

--- a/auto-generated/policy_funcs/gnu-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/gnu-overloaded-tests/vfwcvtbf16.c
@@ -3,195 +3,195 @@
 
 #include <riscv_vector.h>
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e4m3m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e4m3m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e4m3m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vuint8mf8_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm, vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vuint8mf4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm, vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm, vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm, vbfloat16m2_t vd, vfloat8e5m2m1_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm, vbfloat16m4_t vd, vfloat8e5m2m2_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
-vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm, vbfloat16m8_t vd, vfloat8e5m2m4_t vs2, size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 /* { dg-final { scan-assembler-times {vseti?vli\s+[a-z0-9]+,\s*[a-z0-9]+,\s*e[0-9]+,\s*mf?[1248],\s*t[au],\s*m[au]\s+vfwcvtbf16\.[ivxfswum.]+\s+} 48 } } */

--- a/auto-generated/policy_funcs/intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs.adoc
@@ -95325,97 +95325,97 @@ vuint32m8_t __riscv_vdot4au_vx_u32m8_mu(vbool4_t vm, vuint32m8_t vd,
 [,c]
 ----
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e4m3mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e4m3mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e4m3mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e4m3m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e4m3m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e4m3m4_t vs2,
                                                       size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                           vbfloat16mf4_t vd,
-                                                          vuint8mf8_t vs2,
+                                                          vfloat8e4m3mf8_t vs2,
                                                           size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                           vbfloat16mf2_t vd,
-                                                          vuint8mf4_t vs2,
+                                                          vfloat8e4m3mf4_t vs2,
                                                           size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                         vbfloat16m1_t vd,
-                                                        vuint8mf2_t vs2,
+                                                        vfloat8e4m3mf2_t vs2,
                                                         size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                        vbfloat16m2_t vd,
-                                                       vuint8m1_t vs2,
+                                                       vfloat8e4m3m1_t vs2,
                                                        size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                        vbfloat16m4_t vd,
-                                                       vuint8m2_t vs2,
+                                                       vfloat8e4m3m2_t vs2,
                                                        size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                        vbfloat16m8_t vd,
-                                                       vuint8m4_t vs2,
+                                                       vfloat8e4m3m4_t vs2,
                                                        size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                            vbfloat16mf4_t vd,
-                                                           vuint8mf8_t vs2,
+                                                           vfloat8e4m3mf8_t vs2,
                                                            size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                            vbfloat16mf2_t vd,
-                                                           vuint8mf4_t vs2,
+                                                           vfloat8e4m3mf4_t vs2,
                                                            size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                          vbfloat16m1_t vd,
-                                                         vuint8mf2_t vs2,
+                                                         vfloat8e4m3mf2_t vs2,
                                                          size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                         vbfloat16m2_t vd,
-                                                        vuint8m1_t vs2,
+                                                        vfloat8e4m3m1_t vs2,
                                                         size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                         vbfloat16m4_t vd,
-                                                        vuint8m2_t vs2,
+                                                        vfloat8e4m3m2_t vs2,
                                                         size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                         vbfloat16m8_t vd,
-                                                        vuint8m4_t vs2,
+                                                        vfloat8e4m3m4_t vs2,
                                                         size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                          vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e4m3mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                          vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e4m3mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                        vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e4m3mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                       vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e4m3m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                       vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e4m3m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                       vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e4m3m4_t vs2,
                                                       size_t vl);
 ----
 
@@ -95425,97 +95425,97 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
 [,c]
 ----
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e5m2mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e5m2mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e5m2mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e5m2m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e5m2m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e5m2m4_t vs2,
                                                       size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                           vbfloat16mf4_t vd,
-                                                          vuint8mf8_t vs2,
+                                                          vfloat8e5m2mf8_t vs2,
                                                           size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                           vbfloat16mf2_t vd,
-                                                          vuint8mf4_t vs2,
+                                                          vfloat8e5m2mf4_t vs2,
                                                           size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                         vbfloat16m1_t vd,
-                                                        vuint8mf2_t vs2,
+                                                        vfloat8e5m2mf2_t vs2,
                                                         size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                        vbfloat16m2_t vd,
-                                                       vuint8m1_t vs2,
+                                                       vfloat8e5m2m1_t vs2,
                                                        size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                        vbfloat16m4_t vd,
-                                                       vuint8m2_t vs2,
+                                                       vfloat8e5m2m2_t vs2,
                                                        size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                        vbfloat16m8_t vd,
-                                                       vuint8m4_t vs2,
+                                                       vfloat8e5m2m4_t vs2,
                                                        size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                            vbfloat16mf4_t vd,
-                                                           vuint8mf8_t vs2,
+                                                           vfloat8e5m2mf8_t vs2,
                                                            size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                            vbfloat16mf2_t vd,
-                                                           vuint8mf4_t vs2,
+                                                           vfloat8e5m2mf4_t vs2,
                                                            size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                          vbfloat16m1_t vd,
-                                                         vuint8mf2_t vs2,
+                                                         vfloat8e5m2mf2_t vs2,
                                                          size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                         vbfloat16m2_t vd,
-                                                        vuint8m1_t vs2,
+                                                        vfloat8e5m2m1_t vs2,
                                                         size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                         vbfloat16m4_t vd,
-                                                        vuint8m2_t vs2,
+                                                        vfloat8e5m2m2_t vs2,
                                                         size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                         vbfloat16m8_t vd,
-                                                        vuint8m4_t vs2,
+                                                        vfloat8e5m2m4_t vs2,
                                                         size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                          vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e5m2mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                          vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e5m2mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                        vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e5m2mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                       vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e5m2m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                       vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e5m2m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                       vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e5m2m4_t vs2,
                                                       size_t vl);
 ----
 
@@ -95526,353 +95526,342 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                            vbfloat16mf4_t vs2,
                                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                            vbfloat16mf2_t vs2,
                                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                           vbfloat16m1_t vs2,
                                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                         vbfloat16m2_t vs2,
                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                         vbfloat16m4_t vs2,
                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                         vbfloat16m8_t vs2,
                                                         size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
                                                             vbfloat16m1_t vs2,
-                                                            unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
                                                           vbfloat16m2_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
                                                           vbfloat16m4_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
                                                           vbfloat16m8_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vbfloat16mf4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vbfloat16mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                             vuint8mf2_t vd,
-                                                             vbfloat16m1_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
                                                            vbfloat16mf4_t vs2,
-                                                           unsigned int frm,
                                                            size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
                                                            vbfloat16mf2_t vs2,
+                                                           size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(
+    vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(
+    vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(
+    vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(
+    vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(
+    vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(
+    vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                              vuint8mf2_t vd,
-                                                              vbfloat16m1_t vs2,
-                                                              unsigned int frm,
-                                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(
+    vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(
+    vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(
+    vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                             vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                             vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                            vuint8mf2_t vd,
-                                                            vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
                                                             unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vbfloat16m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vbfloat16m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                                vbfloat16m8_t vs2,
+                                                unsigned int frm, size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
+    vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
+    vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
+    vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, unsigned int frm,
+    size_t vl);
+// masked functions
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 [[policy-variant-bf16-to-ofp8-e5m2-conversion-instructions]]
@@ -95880,353 +95869,342 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
                                                            vbfloat16mf4_t vs2,
                                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
                                                            vbfloat16mf2_t vs2,
                                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
                                                           vbfloat16m1_t vs2,
                                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
                                                         vbfloat16m2_t vs2,
                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
                                                         vbfloat16m4_t vs2,
                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
                                                         vbfloat16m8_t vs2,
                                                         size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
                                                             vbfloat16m1_t vs2,
-                                                            unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
                                                           vbfloat16m2_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
                                                           vbfloat16m4_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
                                                           vbfloat16m8_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vbfloat16mf4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vbfloat16mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                             vuint8mf2_t vd,
-                                                             vbfloat16m1_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
                                                            vbfloat16mf4_t vs2,
-                                                           unsigned int frm,
                                                            size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
                                                            vbfloat16mf2_t vs2,
+                                                           size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(
+    vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(
+    vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(
+    vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(
+    vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(
+    vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(
+    vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                              vuint8mf2_t vd,
-                                                              vbfloat16m1_t vs2,
-                                                              unsigned int frm,
-                                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(
+    vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(
+    vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(
+    vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                             vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                             vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                            vuint8mf2_t vd,
-                                                            vbfloat16m1_t vs2,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
                                                             unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vbfloat16m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vbfloat16m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                                vbfloat16m8_t vs2,
+                                                unsigned int frm, size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
+    vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
+    vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
+    vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, unsigned int frm,
+    size_t vl);
+// masked functions
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 === Zvfofp8min - FP32 to OFP8 conversion instructions
@@ -96236,242 +96214,340 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                    vfloat32mf2_t vs2,
                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                    vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                    vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                  vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                  vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
                                                      vfloat32mf2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
                                                      vfloat32m1_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
                                                      vfloat32m2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                      vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
                                                       vfloat32mf2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                      vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
                                                       vfloat32m1_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
                                                       vfloat32m2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
                                                     vfloat32m4_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
                                                     vfloat32m8_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
                                                        vfloat32mf2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vfloat32mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
                                                        vfloat32m1_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vfloat32m1_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
                                                        vfloat32m2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vfloat32m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
                                                      vfloat32m4_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vfloat32m4_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
                                                      vfloat32m8_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vfloat32m8_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vfloat32mf2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vfloat32m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vfloat32m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vfloat32mf2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vfloat32m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vfloat32m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vfloat32m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vfloat32m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 ----
 
 [[policy-variant-fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -96479,242 +96555,340 @@ vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
                                                    vfloat32mf2_t vs2,
                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
                                                    vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
                                                    vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
                                                  vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
                                                  vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
                                                      vfloat32mf2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
                                                      vfloat32m1_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
                                                      vfloat32m2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                      vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
                                                       vfloat32mf2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                      vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
                                                       vfloat32m1_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
                                                       vfloat32m2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
                                                     vfloat32m4_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
                                                     vfloat32m8_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
                                                        vfloat32mf2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vfloat32mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
                                                        vfloat32m1_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vfloat32m1_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
                                                        vfloat32m2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vfloat32m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
                                                      vfloat32m4_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vfloat32m4_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
                                                      vfloat32m8_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vfloat32m8_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vfloat32mf2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vfloat32m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vfloat32m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vfloat32mf2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vfloat32m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vfloat32m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vfloat32m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vfloat32m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 ----
 
 === Zvabd - Vector Absolute Difference instructions

--- a/auto-generated/policy_funcs/intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
@@ -7,97 +7,97 @@
 [,c]
 ----
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e4m3mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e4m3mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e4m3mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e4m3m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e4m3m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e4m3m4_t vs2,
                                                       size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                           vbfloat16mf4_t vd,
-                                                          vuint8mf8_t vs2,
+                                                          vfloat8e4m3mf8_t vs2,
                                                           size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                           vbfloat16mf2_t vd,
-                                                          vuint8mf4_t vs2,
+                                                          vfloat8e4m3mf4_t vs2,
                                                           size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                         vbfloat16m1_t vd,
-                                                        vuint8mf2_t vs2,
+                                                        vfloat8e4m3mf2_t vs2,
                                                         size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                        vbfloat16m2_t vd,
-                                                       vuint8m1_t vs2,
+                                                       vfloat8e4m3m1_t vs2,
                                                        size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                        vbfloat16m4_t vd,
-                                                       vuint8m2_t vs2,
+                                                       vfloat8e4m3m2_t vs2,
                                                        size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                        vbfloat16m8_t vd,
-                                                       vuint8m4_t vs2,
+                                                       vfloat8e4m3m4_t vs2,
                                                        size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                            vbfloat16mf4_t vd,
-                                                           vuint8mf8_t vs2,
+                                                           vfloat8e4m3mf8_t vs2,
                                                            size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                            vbfloat16mf2_t vd,
-                                                           vuint8mf4_t vs2,
+                                                           vfloat8e4m3mf4_t vs2,
                                                            size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                          vbfloat16m1_t vd,
-                                                         vuint8mf2_t vs2,
+                                                         vfloat8e4m3mf2_t vs2,
                                                          size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                         vbfloat16m2_t vd,
-                                                        vuint8m1_t vs2,
+                                                        vfloat8e4m3m1_t vs2,
                                                         size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                         vbfloat16m4_t vd,
-                                                        vuint8m2_t vs2,
+                                                        vfloat8e4m3m2_t vs2,
                                                         size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                         vbfloat16m8_t vd,
-                                                        vuint8m4_t vs2,
+                                                        vfloat8e4m3m4_t vs2,
                                                         size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                          vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e4m3mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                          vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e4m3mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                        vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e4m3mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                       vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e4m3m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                       vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e4m3m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                       vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e4m3m4_t vs2,
                                                       size_t vl);
 ----
 
@@ -107,96 +107,96 @@ vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
 [,c]
 ----
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e5m2mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e5m2mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e5m2mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e5m2m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e5m2m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e5m2m4_t vs2,
                                                       size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                           vbfloat16mf4_t vd,
-                                                          vuint8mf8_t vs2,
+                                                          vfloat8e5m2mf8_t vs2,
                                                           size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                           vbfloat16mf2_t vd,
-                                                          vuint8mf4_t vs2,
+                                                          vfloat8e5m2mf4_t vs2,
                                                           size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                         vbfloat16m1_t vd,
-                                                        vuint8mf2_t vs2,
+                                                        vfloat8e5m2mf2_t vs2,
                                                         size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                        vbfloat16m2_t vd,
-                                                       vuint8m1_t vs2,
+                                                       vfloat8e5m2m1_t vs2,
                                                        size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                        vbfloat16m4_t vd,
-                                                       vuint8m2_t vs2,
+                                                       vfloat8e5m2m2_t vs2,
                                                        size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                        vbfloat16m8_t vd,
-                                                       vuint8m4_t vs2,
+                                                       vfloat8e5m2m4_t vs2,
                                                        size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                            vbfloat16mf4_t vd,
-                                                           vuint8mf8_t vs2,
+                                                           vfloat8e5m2mf8_t vs2,
                                                            size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                            vbfloat16mf2_t vd,
-                                                           vuint8mf4_t vs2,
+                                                           vfloat8e5m2mf4_t vs2,
                                                            size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                          vbfloat16m1_t vd,
-                                                         vuint8mf2_t vs2,
+                                                         vfloat8e5m2mf2_t vs2,
                                                          size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                         vbfloat16m2_t vd,
-                                                        vuint8m1_t vs2,
+                                                        vfloat8e5m2m1_t vs2,
                                                         size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                         vbfloat16m4_t vd,
-                                                        vuint8m2_t vs2,
+                                                        vfloat8e5m2m2_t vs2,
                                                         size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                         vbfloat16m8_t vd,
-                                                        vuint8m4_t vs2,
+                                                        vfloat8e5m2m4_t vs2,
                                                         size_t vl);
 // masked functions
 vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                          vbfloat16mf4_t vd,
-                                                         vuint8mf8_t vs2,
+                                                         vfloat8e5m2mf8_t vs2,
                                                          size_t vl);
 vbfloat16mf2_t __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                          vbfloat16mf2_t vd,
-                                                         vuint8mf4_t vs2,
+                                                         vfloat8e5m2mf4_t vs2,
                                                          size_t vl);
 vbfloat16m1_t __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                        vbfloat16m1_t vd,
-                                                       vuint8mf2_t vs2,
+                                                       vfloat8e5m2mf2_t vs2,
                                                        size_t vl);
 vbfloat16m2_t __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                       vbfloat16m2_t vd,
-                                                      vuint8m1_t vs2,
+                                                      vfloat8e5m2m1_t vs2,
                                                       size_t vl);
 vbfloat16m4_t __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                       vbfloat16m4_t vd,
-                                                      vuint8m2_t vs2,
+                                                      vfloat8e5m2m2_t vs2,
                                                       size_t vl);
 vbfloat16m8_t __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                       vbfloat16m8_t vd,
-                                                      vuint8m4_t vs2,
+                                                      vfloat8e5m2m4_t vs2,
                                                       size_t vl);
 ----

--- a/auto-generated/policy_funcs/intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
@@ -6,353 +6,342 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                            vbfloat16mf4_t vs2,
                                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                            vbfloat16mf2_t vs2,
                                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                           vbfloat16m1_t vs2,
                                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                         vbfloat16m2_t vs2,
                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                         vbfloat16m4_t vs2,
                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                         vbfloat16m8_t vs2,
                                                         size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
                                                             vbfloat16m1_t vs2,
-                                                            unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
                                                           vbfloat16m2_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
                                                           vbfloat16m4_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
                                                           vbfloat16m8_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vbfloat16mf4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vbfloat16mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                             vuint8mf2_t vd,
-                                                             vbfloat16m1_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
                                                            vbfloat16mf4_t vs2,
-                                                           unsigned int frm,
                                                            size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
                                                            vbfloat16mf2_t vs2,
+                                                           size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(
+    vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(
+    vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(
+    vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(
+    vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(
+    vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(
+    vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                              vuint8mf2_t vd,
-                                                              vbfloat16m1_t vs2,
-                                                              unsigned int frm,
-                                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(
+    vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(
+    vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(
+    vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                             vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                             vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                            vuint8mf2_t vd,
-                                                            vbfloat16m1_t vs2,
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
                                                             unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vbfloat16m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vbfloat16m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                                vbfloat16m8_t vs2,
+                                                unsigned int frm, size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(
+    vbool8_t vm, vfloat8e4m3m1_t vd, vbfloat16m2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(
+    vbool4_t vm, vfloat8e4m3m2_t vd, vbfloat16m4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(
+    vbool2_t vm, vfloat8e4m3m4_t vd, vbfloat16m8_t vs2, unsigned int frm,
+    size_t vl);
+// masked functions
+vfloat8e4m3mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 [[policy-variant-bf16-to-ofp8-e5m2-conversion-instructions]]
@@ -360,351 +349,340 @@ vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
                                                            vbfloat16mf4_t vs2,
                                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
                                                            vbfloat16mf2_t vs2,
                                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
                                                           vbfloat16m1_t vs2,
                                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
                                                         vbfloat16m2_t vs2,
                                                         size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
                                                         vbfloat16m4_t vs2,
                                                         size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
                                                         vbfloat16m8_t vs2,
                                                         size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
                                                             vbfloat16m1_t vs2,
-                                                            unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
                                                           vbfloat16m2_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
                                                           vbfloat16m4_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      unsigned int frm,
-                                                      size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
                                                           vbfloat16m8_t vs2,
-                                                          unsigned int frm,
                                                           size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vbfloat16mf4_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vbfloat16mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                             vuint8mf2_t vd,
-                                                             vbfloat16m1_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                           vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
                                                            vbfloat16mf4_t vs2,
-                                                           unsigned int frm,
                                                            size_t vl);
-vuint8mf8_t
-__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                           vuint8mf4_t vd,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
                                                            vbfloat16mf2_t vs2,
+                                                           size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(
+    vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(
+    vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(
+    vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(
+    vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(
+    vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(
+    vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
                                                            unsigned int frm,
                                                            size_t vl);
-vuint8mf4_t
-__riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          unsigned int frm,
-                                                          size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                              vuint8mf2_t vd,
-                                                              vbfloat16m1_t vs2,
-                                                              unsigned int frm,
-                                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(
+    vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(
+    vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(
+    vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                             vuint8mf8_t vd,
-                                                             vbfloat16mf4_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         unsigned int frm,
-                                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                             vuint8mf4_t vd,
-                                                             vbfloat16mf2_t vs2,
-                                                             unsigned int frm,
-                                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        unsigned int frm,
-                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                            vuint8mf2_t vd,
-                                                            vbfloat16m1_t vs2,
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
                                                             unsigned int frm,
                                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(
-    vbool8_t vm, vuint8m1_t vd, vbfloat16m2_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(
-    vbool4_t vm, vuint8m2_t vd, vbfloat16m4_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(
-    vbool2_t vm, vuint8m4_t vd, vbfloat16m8_t vs2, unsigned int frm, size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vbfloat16m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vbfloat16m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                                vbfloat16m8_t vs2,
+                                                unsigned int frm, size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(
+    vbool8_t vm, vfloat8e5m2m1_t vd, vbfloat16m2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(
+    vbool4_t vm, vfloat8e5m2m2_t vd, vbfloat16m4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             unsigned int frm,
+                                                             size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(
+    vbool2_t vm, vfloat8e5m2m4_t vd, vbfloat16m8_t vs2, unsigned int frm,
+    size_t vl);
+// masked functions
+vfloat8e5m2mf8_t
+__riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf4_t
+__riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2,
+                                             unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2mf2_t
+__riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, unsigned int frm,
+    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m1_t
+__riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m2_t
+__riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m4_t
+__riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----

--- a/auto-generated/policy_funcs/intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
@@ -6,242 +6,340 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                    vfloat32mf2_t vs2,
                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                    vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                    vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                  vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                  vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
                                                      vfloat32mf2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
                                                      vfloat32m1_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
                                                      vfloat32m2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                      vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
                                                       vfloat32mf2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                      vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
                                                       vfloat32m1_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
                                                       vfloat32m2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
                                                     vfloat32m4_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
                                                     vfloat32m8_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
                                                        vfloat32mf2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vfloat32mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
                                                        vfloat32m1_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vfloat32m1_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
                                                        vfloat32m2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vfloat32m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
                                                      vfloat32m4_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vfloat32m4_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
                                                      vfloat32m8_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vfloat32m8_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vfloat32mf2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vfloat32m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vfloat32m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vfloat32mf2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vfloat32m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vfloat32m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vfloat32m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vfloat32m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 ----
 
 [[policy-variant-fp32-to-ofp8-e5m2-conversion-instructions]]
@@ -249,240 +347,338 @@ vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
                                                    vfloat32mf2_t vs2,
                                                    size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
                                                    vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
                                                    vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
                                                  vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
                                                  vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
                                                      vfloat32mf2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
                                                      vfloat32m1_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
                                                      vfloat32m2_t vs2,
-                                                     unsigned int frm,
                                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                      vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
                                                       vfloat32mf2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                      vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
                                                       vfloat32m1_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2,
-                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
                                                       vfloat32m2_t vs2,
                                                       unsigned int frm,
                                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
                                                     vfloat32m4_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2,
-                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
                                                     vfloat32m8_t vs2,
                                                     unsigned int frm,
                                                     size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
                                                        vfloat32mf2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vfloat32mf2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
                                                        vfloat32m1_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vfloat32m1_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
                                                        vfloat32m2_t vs2,
                                                        unsigned int frm,
                                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vfloat32m2_t vs2,
+                                                           unsigned int frm,
+                                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
                                                      vfloat32m4_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vfloat32m4_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
                                                      vfloat32m8_t vs2,
                                                      unsigned int frm,
                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vfloat32m8_t vs2,
+                                                         unsigned int frm,
+                                                         size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vfloat32mf2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vfloat32m1_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2,
-                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vfloat32m2_t vs2,
-                                                     unsigned int frm,
-                                                     size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vfloat32m4_t vs2,
-                                                   unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2,
-                                               unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vfloat32m8_t vs2,
-                                                   unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vfloat32mf2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vfloat32m1_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vfloat32m2_t vs2,
+                                                            unsigned int frm,
+                                                            size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vfloat32m4_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vfloat32m8_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
+                                                          vfloat32mf2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
+                                                          vfloat32m1_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      unsigned int frm,
+                                                      size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vfloat32m2_t vs2,
+                                                          unsigned int frm,
+                                                          size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vfloat32m4_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    unsigned int frm,
+                                                    size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vfloat32m8_t vs2,
+                                                        unsigned int frm,
+                                                        size_t vl);
 ----

--- a/auto-generated/policy_funcs/llvm-api-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfncvt.c
@@ -2284,870 +2284,1058 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfncvt_f_f_w_f32m4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vfloat32mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vfloat32m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vfloat32m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vfloat32mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vfloat32m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                 vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vfloat32m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                    vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                   vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vm, vd, vs2, __RISCV_FRM_RNE,
                                                  vl);
 }

--- a/auto-generated/policy_funcs/llvm-api-tests/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfncvtbf16.c
@@ -7,1320 +7,1346 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                      vfloat8e4m3m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                       vfloat8e4m3m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                     vfloat8e4m3m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
-                                                            vbfloat16mf4_t vs2,
-                                                            size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
-                                                            vbfloat16mf2_t vs2,
-                                                            size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
-                                                           vbfloat16m1_t vs2,
-                                                           size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
-                                                         vbfloat16m2_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
-                                                         vbfloat16m4_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
-                                                         vbfloat16m8_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vbfloat16m2_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                      vfloat8e5m2m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
+                                                          vbfloat16mf4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
+                                                          vbfloat16mf2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vbfloat16m1_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vbfloat16m2_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vbfloat16m4_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                       vfloat8e5m2m4_t vd,
+                                                       vbfloat16m8_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                     vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                       vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                      vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2, __RISCV_FRM_RNE,
                                                     vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
-                                                            vbfloat16mf4_t vs2,
-                                                            size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
-                                                            vbfloat16mf2_t vs2,
-                                                            size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
       vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                        __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
-                                                           vbfloat16m1_t vs2,
-                                                           size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vm, vd, vs2,
                                                            __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
-                                                         vbfloat16m2_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
-                                                         vbfloat16m4_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
-                                                         vbfloat16m8_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2,
                                                       __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vm, vd, vs2,
                                                           __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2,
                                                      __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vm, vd, vs2,
                                                          __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
   return __riscv_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2,
                                                     __RISCV_FRM_RNE, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
   return __riscv_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vm, vd, vs2,
                                                         __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/llvm-api-tests/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/llvm-api-tests/vfwcvtbf16.c
@@ -8,307 +8,325 @@
 #include <riscv_vector.h>
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e4m3mf8_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e4m3mf4_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e4m3mf2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
+                                                    vfloat8e4m3m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
+                                                    vfloat8e4m3m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
+                                                    vfloat8e4m3m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e4m3m1_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e4m3m2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e4m3m4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e5m2mf8_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e5m2mf4_t vs2,
                                                        size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e5m2mf2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
+                                                    vfloat8e5m2m1_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
+                                                    vfloat8e5m2m2_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
+                                                    vfloat8e5m2m4_t vs2,
+                                                    size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e5m2m1_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e5m2m2_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e5m2m4_t vs2,
                                                      size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
   return __riscv_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vm, vd, vs2, vl);
 }

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvt.c
@@ -2284,824 +2284,1012 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfncvt_f_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vfloat32mf2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vfloat32mf2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfncvtbf16.c
@@ -7,1236 +7,1250 @@
 
 #include <riscv_vector.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                         vbfloat16mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                         vbfloat16mf2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                        vbfloat16m1_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                      vbfloat16m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                      vbfloat16m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                      vbfloat16m8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
                                                          vbfloat16mf4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
                                                          vbfloat16mf2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
                                                         vbfloat16m1_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
                                                       vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
                                                       vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                      vfloat8e4m3m4_t vd,
                                                       vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
                                                           vbfloat16mf4_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
                                                           vbfloat16mf2_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
                                                          vbfloat16m1_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
                                                        vbfloat16m2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
                                                        vbfloat16m4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                       vfloat8e4m3m4_t vd,
                                                        vbfloat16m8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
                                                         vbfloat16mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
                                                         vbfloat16mf2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
                                                        vbfloat16m1_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
                                                      vbfloat16m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
                                                      vbfloat16m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                     vfloat8e4m3m4_t vd,
                                                      vbfloat16m8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                      vfloat8e5m2m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
                                                           vbfloat16mf4_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
                                                           vbfloat16mf2_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
                                                          vbfloat16m1_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
                                                        vbfloat16m2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
                                                        vbfloat16m4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                       vfloat8e5m2m4_t vd,
                                                        vbfloat16m8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                     vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/llvm-overloaded-tests/vfwcvtbf16.c
@@ -8,307 +8,325 @@
 #include <riscv_vector.h>
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e4m3mf8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e4m3mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e4m3mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e4m3m1_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e4m3m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e4m3m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e5m2mf8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e5m2mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e5m2mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e5m2m1_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e5m2m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e5m2m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfncvt.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfncvt.c
@@ -2278,824 +2278,1012 @@ vfloat32m4_t test_vfncvt_f_f_w_f32m4_rm_mu(vbool8_t vm, vfloat32m4_t vd,
   return __riscv_vfncvt_f_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                  vfloat32mf2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                               size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                         size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                            vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                            vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                            vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                              vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                              vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                             vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                             vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tum(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                             vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tum(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tum(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tum(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tum(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                         vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                         vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vfloat32mf2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_tumu(vbool64_t vm,
+                                                      vfloat8e4m3mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                              size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_tumu(vbool32_t vm,
+                                                      vfloat8e4m3mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_tumu(vbool16_t vm,
+                                                      vfloat8e4m3mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                            size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_tumu(vbool8_t vm,
+                                                    vfloat8e4m3m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                                size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                               vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_tumu(vbool4_t vm,
+                                                    vfloat8e4m3m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm, vuint8mf8_t vd,
-                                                   vfloat32mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                               vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm, vuint8mf4_t vd,
-                                                   vfloat32m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                               vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vfloat32m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                             vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                             vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                    vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_mu(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
                                                     vfloat32mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                    vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_mu(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
                                                     vfloat32m1_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_mu(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
                                                     vfloat32m2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                               vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_mu(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
                                                   vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                               vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_mu(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
                                                   vfloat32m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
-                                              vfloat32mf2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e4m3mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e4m3mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e4m3mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e4m3m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e4m3m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e4m3mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e4m3mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e4m3mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e4m3m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e4m3m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e4m3mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_q_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e4m3mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e4m3mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_q_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e4m3mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e4m3mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_q_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_q_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_q_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tum(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tum(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tum(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tum(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tum(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vfloat32mf2_t vs2,
                                                   size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
-                                              vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_tumu(vbool64_t vm,
+                                                      vfloat8e5m2mf8_t vd,
+                                                      vfloat32mf2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vfloat32m1_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
-                                              vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_tumu(vbool32_t vm,
+                                                      vfloat8e5m2mf4_t vd,
+                                                      vfloat32m1_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vfloat32m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                            vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_tumu(vbool16_t vm,
+                                                      vfloat8e5m2mf2_t vd,
+                                                      vfloat32m2_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vfloat32m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                            vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_tumu(vbool8_t vm,
+                                                    vfloat8e5m2m1_t vd,
+                                                    vfloat32m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_tumu(vbool4_t vm,
+                                                    vfloat8e5m2m2_t vd,
+                                                    vfloat32m8_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_mu(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_mu(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_mu(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_mu(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_mu(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                    vfloat8e5m2mf8_t vd,
+                                                    vfloat32mf2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vfloat32mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                    vfloat8e5m2mf4_t vd,
+                                                    vfloat32m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vfloat32m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                    vfloat8e5m2mf2_t vd,
+                                                    vfloat32m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vfloat32m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                  vfloat8e5m2m1_t vd,
+                                                  vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vfloat32m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                  vfloat8e5m2m2_t vd,
+                                                  vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vfloat32m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                     vfloat8e5m2mf8_t vd,
+                                                     vfloat32mf2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_tumu(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vfloat32mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                     vfloat8e5m2mf4_t vd,
+                                                     vfloat32m1_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_tumu(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vfloat32m1_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                     vfloat8e5m2mf2_t vd,
+                                                     vfloat32m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
+                                                         vfloat32m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                   vfloat8e5m2m1_t vd,
+                                                   vfloat32m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
+                                                       vfloat32m4_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                   vfloat8e5m2m2_t vd,
+                                                   vfloat32m8_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
+                                                       vfloat32m8_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                   vfloat8e5m2mf8_t vd,
+                                                   vfloat32mf2_t vs2,
+                                                   size_t vl) {
   return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vfloat32m8_t vs2, size_t vl) {
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_q_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                       vfloat8e5m2mf8_t vd,
+                                                       vfloat32mf2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                   vfloat8e5m2mf4_t vd,
+                                                   vfloat32m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_q_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                       vfloat8e5m2mf4_t vd,
+                                                       vfloat32m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                   vfloat8e5m2mf2_t vd,
+                                                   vfloat32m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_q_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vfloat32m2_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_q_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vfloat32m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_q_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vfloat32m8_t vs2,
+                                                     size_t vl) {
   return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfncvtbf16.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfncvtbf16.c
@@ -1,1236 +1,1250 @@
 #include <riscv_vector.h>
 #include <stdint.h>
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                         vbfloat16mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
-                                                         vbfloat16mf4_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
-                                                         vbfloat16mf2_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
-                                                        vbfloat16m1_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
-                                                      vbfloat16m2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
-                                                      vbfloat16m4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
-                                                      vbfloat16m8_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tu(vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                         vbfloat16mf2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tu(vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                        vbfloat16m1_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tu(vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                      vbfloat16m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tu(vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                      vbfloat16m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tu(vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                      vbfloat16m8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tu(vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
-                                                          vbfloat16mf4_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
-                                                          vbfloat16mf2_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
-                                                         vbfloat16m1_t vs2,
-                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
-                                                       vbfloat16m2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
-                                                       vbfloat16m4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
-                                                       vbfloat16m8_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                    vuint8mf8_t vd,
-                                                    vbfloat16mf4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
-                                                        vuint8mf8_t vd,
-                                                        vbfloat16mf4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                    vuint8mf4_t vd,
-                                                    vbfloat16mf2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
-                                                        vuint8mf4_t vd,
-                                                        vbfloat16mf2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                                   vbfloat16m1_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
-                                                       vuint8mf2_t vd,
-                                                       vbfloat16m1_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                 vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm, vuint8m1_t vd,
-                                                     vbfloat16m2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                 vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                                     vbfloat16m4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                 vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm, vuint8m4_t vd,
-                                                     vbfloat16m8_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                     vuint8mf8_t vd,
-                                                     vbfloat16mf4_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
-                                                         vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm,
+                                                         vfloat8e4m3mf8_t vd,
                                                          vbfloat16mf4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                     vuint8mf4_t vd,
-                                                     vbfloat16mf2_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
-                                                         vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm,
+                                                         vfloat8e4m3mf4_t vd,
                                                          vbfloat16mf2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                    vuint8mf2_t vd,
-                                                    vbfloat16m1_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
-                                                        vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                        vfloat8e4m3mf2_t vd,
                                                         vbfloat16m1_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm, vuint8m1_t vd,
-                                                  vbfloat16m2_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tum(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
-                                                      vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                      vfloat8e4m3m1_t vd,
                                                       vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                                  vbfloat16m4_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tum(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
-                                                      vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                      vfloat8e4m3m2_t vd,
                                                       vbfloat16m4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm, vuint8m4_t vd,
-                                                  vbfloat16m8_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tum(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
-                                                      vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                      vfloat8e4m3m4_t vd,
                                                       vbfloat16m8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, vl);
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm, vuint8mf8_t vd,
-                                                   vbfloat16mf4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tum(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm, vuint8mf4_t vd,
-                                                   vbfloat16mf2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                                  vbfloat16m1_t vs2,
-                                                  size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                vbfloat16m2_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                vbfloat16m4_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                vbfloat16m8_t vs2, size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm,
+                                                          vfloat8e4m3mf8_t vd,
                                                           vbfloat16mf4_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm,
+                                                          vfloat8e4m3mf4_t vd,
                                                           vbfloat16mf2_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm,
+                                                         vfloat8e4m3mf2_t vd,
                                                          vbfloat16m1_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                       vfloat8e4m3m1_t vd,
                                                        vbfloat16m2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_tumu(vbool8_t vm,
+                                                           vfloat8e4m3m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                       vfloat8e4m3m2_t vd,
                                                        vbfloat16m4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_tumu(vbool4_t vm,
+                                                           vfloat8e4m3m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                       vfloat8e4m3m4_t vd,
                                                        vbfloat16m8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                       vuint8mf8_t vd,
-                                                       vbfloat16mf4_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
-                                                           vuint8mf8_t vd,
-                                                           vbfloat16mf4_t vs2,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_tumu(vbool2_t vm,
+                                                           vfloat8e4m3m4_t vd,
+                                                           vbfloat16m8_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                       vuint8mf4_t vd,
-                                                       vbfloat16mf2_t vs2,
-                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
-                                                           vuint8mf4_t vd,
-                                                           vbfloat16mf2_t vs2,
-                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                      vuint8mf2_t vd,
-                                                      vbfloat16m1_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
-                                                          vuint8mf2_t vd,
-                                                          vbfloat16m1_t vs2,
-                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm, vuint8m1_t vd,
-                                                    vbfloat16m2_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
-                                                        vuint8m1_t vd,
-                                                        vbfloat16m2_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm, vuint8m2_t vd,
-                                                    vbfloat16m4_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
-                                                        vuint8m2_t vd,
-                                                        vbfloat16m4_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm, vuint8m4_t vd,
-                                                    vbfloat16m8_t vs2,
-                                                    size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
-                                                        vuint8m4_t vd,
-                                                        vbfloat16m8_t vs2,
-                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
-}
-
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                        vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                        vfloat8e4m3mf8_t vd,
                                                         vbfloat16mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm,
-                                                            vuint8mf8_t vd,
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_mu(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
                                                             vbfloat16mf4_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                        vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                        vfloat8e4m3mf4_t vd,
                                                         vbfloat16mf2_t vs2,
                                                         size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm,
-                                                            vuint8mf4_t vd,
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_mu(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
                                                             vbfloat16mf2_t vs2,
                                                             size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                       vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                       vfloat8e4m3mf2_t vd,
                                                        vbfloat16m1_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
-                                                           vuint8mf2_t vd,
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_mu(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
                                                            vbfloat16m1_t vs2,
                                                            size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                     vfloat8e4m3m1_t vd,
                                                      vbfloat16m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
-                                                         vuint8m1_t vd,
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_mu(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
                                                          vbfloat16m2_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                     vfloat8e4m3m2_t vd,
                                                      vbfloat16m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
-                                                         vuint8m2_t vd,
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_mu(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
                                                          vbfloat16m4_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                     vfloat8e4m3m4_t vd,
                                                      vbfloat16m8_t vs2,
                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
-                                                         vuint8m4_t vd,
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_mu(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
                                                          vbfloat16m8_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE,
-                                               vl);
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                      vuint8mf8_t vd,
-                                                      vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tu(vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tu(vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tu(vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tu(vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tu(vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tu(vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e4m3mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tum(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e4m3mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tum(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e4m3mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e4m3m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e4m3m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e4m3m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e4m3m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e4m3m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e4m3m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_tumu(
+    vbool64_t vm, vfloat8e4m3mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_tumu(
+    vbool32_t vm, vfloat8e4m3mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e4m3mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_tumu(
+    vbool16_t vm, vfloat8e4m3mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e4m3m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e4m3m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e4m3m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t test_vfncvt_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e4m3mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8_rm_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t test_vfncvt_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e4m3mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e4m3mf4_rm_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t test_vfncvt_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e4m3mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e4m3mf2_rm_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e4m3m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e4m3m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e4m3m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e4m3m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e4m3m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e4m3m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e4m3m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e4m3m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e4m3m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e4m3m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e4m3_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tu(vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tu(vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tu(vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tu(vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tu(vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tu(vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm,
+                                                         vfloat8e5m2mf8_t vd,
+                                                         vbfloat16mf4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm,
+                                                         vfloat8e5m2mf4_t vd,
+                                                         vbfloat16mf2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                        vfloat8e5m2mf2_t vd,
+                                                        vbfloat16m1_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tum(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                      vfloat8e5m2m1_t vd,
+                                                      vbfloat16m2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
 }
 
-vuint8mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
-                                                          vuint8mf8_t vd,
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tum(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                      vfloat8e5m2m2_t vd,
+                                                      vbfloat16m4_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tum(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                      vfloat8e5m2m4_t vd,
+                                                      vbfloat16m8_t vs2,
+                                                      size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tum(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm,
+                                                          vfloat8e5m2mf8_t vd,
                                                           vbfloat16mf4_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                      vuint8mf4_t vd,
-                                                      vbfloat16mf2_t vs2,
-                                                      size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                             vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
-                                                          vuint8mf4_t vd,
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm,
+                                                          vfloat8e5m2mf4_t vd,
                                                           vbfloat16mf2_t vs2,
                                                           size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                     vuint8mf2_t vd,
-                                                     vbfloat16m1_t vs2,
-                                                     size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                             vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
-                                                         vuint8mf2_t vd,
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm,
+                                                         vfloat8e5m2mf2_t vd,
                                                          vbfloat16m1_t vs2,
                                                          size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm, vuint8m1_t vd,
-                                                   vbfloat16m2_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
-                                                       vuint8m1_t vd,
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                       vfloat8e5m2m1_t vd,
                                                        vbfloat16m2_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm, vuint8m2_t vd,
-                                                   vbfloat16m4_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_tumu(vbool8_t vm,
+                                                           vfloat8e5m2m1_t vd,
+                                                           vbfloat16m2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
-                                                       vuint8m2_t vd,
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                       vfloat8e5m2m2_t vd,
                                                        vbfloat16m4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm, vuint8m4_t vd,
-                                                   vbfloat16m8_t vs2,
-                                                   size_t vl) {
-  return __riscv_vfncvt_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_tumu(vbool4_t vm,
+                                                           vfloat8e5m2m2_t vd,
+                                                           vbfloat16m4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
 }
 
-vuint8m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
-                                                       vuint8m4_t vd,
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                       vfloat8e5m2m4_t vd,
                                                        vbfloat16m8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_tumu(vbool2_t vm,
+                                                           vfloat8e5m2m4_t vd,
+                                                           vbfloat16m8_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                        vfloat8e5m2mf8_t vd,
+                                                        vbfloat16mf4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_mu(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                        vfloat8e5m2mf4_t vd,
+                                                        vbfloat16mf2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_mu(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                       vfloat8e5m2mf2_t vd,
+                                                       vbfloat16m1_t vs2,
+                                                       size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_mu(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                     vfloat8e5m2m1_t vd,
+                                                     vbfloat16m2_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_mu(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                     vfloat8e5m2m2_t vd,
+                                                     vbfloat16m4_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_mu(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                     vfloat8e5m2m4_t vd,
+                                                     vbfloat16m8_t vs2,
+                                                     size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_mu(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tu(vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tu(vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tu(vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tu(vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tu(vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tu(vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tu(vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(vbool64_t vm,
+                                                            vfloat8e5m2mf8_t vd,
+                                                            vbfloat16mf4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tum(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(vbool32_t vm,
+                                                            vfloat8e5m2mf4_t vd,
+                                                            vbfloat16mf2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tum(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm,
+                                                           vfloat8e5m2mf2_t vd,
+                                                           vbfloat16m1_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                         vfloat8e5m2m1_t vd,
+                                                         vbfloat16m2_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tum(vbool8_t vm,
+                                                             vfloat8e5m2m1_t vd,
+                                                             vbfloat16m2_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                         vfloat8e5m2m2_t vd,
+                                                         vbfloat16m4_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tum(vbool4_t vm,
+                                                             vfloat8e5m2m2_t vd,
+                                                             vbfloat16m4_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                         vfloat8e5m2m4_t vd,
+                                                         vbfloat16m8_t vs2,
+                                                         size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tum(vbool2_t vm,
+                                                             vfloat8e5m2m4_t vd,
+                                                             vbfloat16m8_t vs2,
+                                                             size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tum(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_tumu(
+    vbool64_t vm, vfloat8e5m2mf8_t vd, vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_tumu(
+    vbool32_t vm, vfloat8e5m2mf4_t vd, vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(vbool16_t vm,
+                                                            vfloat8e5m2mf2_t vd,
+                                                            vbfloat16m1_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_tumu(
+    vbool16_t vm, vfloat8e5m2mf2_t vd, vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm,
+                                                          vfloat8e5m2m1_t vd,
+                                                          vbfloat16m2_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t
+test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                              vbfloat16m2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm,
+                                                          vfloat8e5m2m2_t vd,
+                                                          vbfloat16m4_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t
+test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                              vbfloat16m4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm,
+                                                          vfloat8e5m2m4_t vd,
+                                                          vbfloat16m8_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t
+test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
+                                              vbfloat16m8_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_tumu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t test_vfncvt_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm,
+                                                           vfloat8e5m2mf8_t vd,
+                                                           vbfloat16mf4_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf8_t
+test_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8_rm_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vbfloat16mf4_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t test_vfncvt_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm,
+                                                           vfloat8e5m2mf4_t vd,
+                                                           vbfloat16mf2_t vs2,
+                                                           size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf4_t
+test_vfncvt_sat_f_f_w_bf16mf2_f8e5m2mf4_rm_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vbfloat16mf2_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t test_vfncvt_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm,
+                                                          vfloat8e5m2mf2_t vd,
+                                                          vbfloat16m1_t vs2,
+                                                          size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2mf2_t
+test_vfncvt_sat_f_f_w_bf16m1_f8e5m2mf2_rm_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                             vbfloat16m1_t vs2, size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                        vfloat8e5m2m1_t vd,
+                                                        vbfloat16m2_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m1_t test_vfncvt_sat_f_f_w_bf16m2_f8e5m2m1_rm_mu(vbool8_t vm,
+                                                            vfloat8e5m2m1_t vd,
+                                                            vbfloat16m2_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                        vfloat8e5m2m2_t vd,
+                                                        vbfloat16m4_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m2_t test_vfncvt_sat_f_f_w_bf16m4_f8e5m2m2_rm_mu(vbool4_t vm,
+                                                            vfloat8e5m2m2_t vd,
+                                                            vbfloat16m4_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                        vfloat8e5m2m4_t vd,
+                                                        vbfloat16m8_t vs2,
+                                                        size_t vl) {
+  return __riscv_vfncvt_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
+}
+
+vfloat8e5m2m4_t test_vfncvt_sat_f_f_w_bf16m8_f8e5m2m4_rm_mu(vbool2_t vm,
+                                                            vfloat8e5m2m4_t vd,
+                                                            vbfloat16m8_t vs2,
+                                                            size_t vl) {
+  return __riscv_vfncvt_sat_f_f8e5m2_mu(vm, vd, vs2, __RISCV_FRM_RNE, vl);
 }

--- a/auto-generated/policy_funcs/overloaded-api-testing/vfwcvtbf16.c
+++ b/auto-generated/policy_funcs/overloaded-api-testing/vfwcvtbf16.c
@@ -2,307 +2,325 @@
 #include <stdint.h>
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e4m3mf8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e4m3mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e4m3mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e4m3m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e4m3mf8_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e4m3mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e4m3mf2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e4m3m1_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e4m3m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e4m3m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e4m3mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e4m3mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e4m3mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e4m3mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e4m3mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e4m3m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e4m3m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e4m3m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e4m3_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e4m3m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tu(vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tu(vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tu(vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tu(vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tu(vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tu(vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tu(vd, vs2, vl);
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tu(vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tum(vbool64_t vm,
                                                        vbfloat16mf4_t vd,
-                                                       vuint8mf8_t vs2,
+                                                       vfloat8e5m2mf8_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tum(vbool32_t vm,
                                                        vbfloat16mf2_t vd,
-                                                       vuint8mf4_t vs2,
+                                                       vfloat8e5m2mf4_t vs2,
                                                        size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tum(vbool16_t vm,
                                                      vbfloat16m1_t vd,
-                                                     vuint8mf2_t vs2,
+                                                     vfloat8e5m2mf2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tum(vbool8_t vm,
                                                     vbfloat16m2_t vd,
-                                                    vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m1_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tum(vbool4_t vm,
                                                     vbfloat16m4_t vd,
-                                                    vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m2_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tum(vbool2_t vm,
                                                     vbfloat16m8_t vd,
-                                                    vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tum(vm, vd, vs2, vl);
+                                                    vfloat8e5m2m4_t vs2,
+                                                    size_t vl) {
+  return __riscv_vfwcvt_f_bf16_tum(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_tumu(vbool64_t vm,
                                                         vbfloat16mf4_t vd,
-                                                        vuint8mf8_t vs2,
+                                                        vfloat8e5m2mf8_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_tumu(vbool32_t vm,
                                                         vbfloat16mf2_t vd,
-                                                        vuint8mf4_t vs2,
+                                                        vfloat8e5m2mf4_t vs2,
                                                         size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_tumu(vbool16_t vm,
                                                       vbfloat16m1_t vd,
-                                                      vuint8mf2_t vs2,
+                                                      vfloat8e5m2mf2_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_tumu(vbool8_t vm,
                                                      vbfloat16m2_t vd,
-                                                     vuint8m1_t vs2,
+                                                     vfloat8e5m2m1_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_tumu(vbool4_t vm,
                                                      vbfloat16m4_t vd,
-                                                     vuint8m2_t vs2,
+                                                     vfloat8e5m2m2_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_tumu(vbool2_t vm,
                                                      vbfloat16m8_t vd,
-                                                     vuint8m4_t vs2,
+                                                     vfloat8e5m2m4_t vs2,
                                                      size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_tumu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf4_t test_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4_mu(vbool64_t vm,
                                                       vbfloat16mf4_t vd,
-                                                      vuint8mf8_t vs2,
+                                                      vfloat8e5m2mf8_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16mf2_t test_vfwcvt_f_f_v_f8e5m2mf4_bf16mf2_mu(vbool32_t vm,
                                                       vbfloat16mf2_t vd,
-                                                      vuint8mf4_t vs2,
+                                                      vfloat8e5m2mf4_t vs2,
                                                       size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m1_t test_vfwcvt_f_f_v_f8e5m2mf2_bf16m1_mu(vbool16_t vm,
                                                     vbfloat16m1_t vd,
-                                                    vuint8mf2_t vs2,
+                                                    vfloat8e5m2mf2_t vs2,
                                                     size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m2_t test_vfwcvt_f_f_v_f8e5m2m1_bf16m2_mu(vbool8_t vm,
                                                    vbfloat16m2_t vd,
-                                                   vuint8m1_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m1_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m4_t test_vfwcvt_f_f_v_f8e5m2m2_bf16m4_mu(vbool4_t vm,
                                                    vbfloat16m4_t vd,
-                                                   vuint8m2_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m2_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }
 
 vbfloat16m8_t test_vfwcvt_f_f_v_f8e5m2m4_bf16m8_mu(vbool2_t vm,
                                                    vbfloat16m8_t vd,
-                                                   vuint8m4_t vs2, size_t vl) {
-  return __riscv_vfwcvt_f_f8e5m2_bf16_mu(vm, vd, vs2, vl);
+                                                   vfloat8e5m2m4_t vs2,
+                                                   size_t vl) {
+  return __riscv_vfwcvt_f_bf16_mu(vm, vd, vs2, vl);
 }

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs.adoc
@@ -78140,59 +78140,57 @@ vuint32m8_t __riscv_vdot4au_mu(vbool4_t vm, vuint32m8_t vd, vuint32m8_t vs2,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m1_t vd, vuint8mf2_t vs2,
-                                              size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m2_t vd, vuint8m1_t vs2,
-                                              size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m4_t vd, vuint8m2_t vs2,
-                                              size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m8_t vd, vuint8m4_t vs2,
-                                              size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2,
+                                        size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2,
+                                       size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m2_t vd, vfloat8e4m3m1_t vs2,
+                                       size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m4_t vd, vfloat8e4m3m2_t vs2,
+                                       size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m8_t vd, vfloat8e4m3m4_t vs2,
+                                       size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
-                                                vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
-                                                vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
-                                               vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
-                                               vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
-                                               vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
-                                               vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
+                                         vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
+                                         vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
+                                        vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
+                                        vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
+                                        vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
+                                        vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool64_t vm,
-                                                 vbfloat16mf4_t vd,
-                                                 vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool32_t vm,
-                                                 vbfloat16mf2_t vd,
-                                                 vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
-                                                vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
-                                                vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
-                                                vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
-                                                vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tumu(vbool64_t vm, vbfloat16mf4_t vd,
+                                          vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tumu(vbool32_t vm, vbfloat16mf2_t vd,
+                                          vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
+                                         vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
+                                         vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
+                                         vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
+                                         vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
-                                              vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
-                                              vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
-                                              vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
-                                              vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
+                                        vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
+                                        vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
+                                       vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
+                                       vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
+                                       vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
+                                       vfloat8e4m3m4_t vs2, size_t vl);
 ----
 
 [[policy-variant-overloadedofp8-e5m2-to-bf16-conversion-instructions]]
@@ -78200,59 +78198,57 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m1_t vd, vuint8mf2_t vs2,
-                                              size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m2_t vd, vuint8m1_t vs2,
-                                              size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m4_t vd, vuint8m2_t vs2,
-                                              size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m8_t vd, vuint8m4_t vs2,
-                                              size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2,
+                                        size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2,
+                                       size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m2_t vd, vfloat8e5m2m1_t vs2,
+                                       size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m4_t vd, vfloat8e5m2m2_t vs2,
+                                       size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m8_t vd, vfloat8e5m2m4_t vs2,
+                                       size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
-                                                vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
-                                                vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
-                                               vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
-                                               vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
-                                               vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
-                                               vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
+                                         vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
+                                         vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
+                                        vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
+                                        vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
+                                        vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
+                                        vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool64_t vm,
-                                                 vbfloat16mf4_t vd,
-                                                 vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool32_t vm,
-                                                 vbfloat16mf2_t vd,
-                                                 vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
-                                                vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
-                                                vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
-                                                vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
-                                                vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tumu(vbool64_t vm, vbfloat16mf4_t vd,
+                                          vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tumu(vbool32_t vm, vbfloat16mf2_t vd,
+                                          vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
+                                         vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
+                                         vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
+                                         vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
+                                         vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
-                                              vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
-                                              vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
-                                              vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
-                                              vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
+                                        vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
+                                        vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
+                                       vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
+                                       vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
+                                       vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
+                                       vfloat8e5m2m4_t vs2, size_t vl);
 ----
 
 === Zvfofp8min - BF16 to OFP8 conversion instructions
@@ -78262,243 +78258,276 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
-                                            size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
-                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                               size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                               size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                           vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                           vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                           vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                 vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                 vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                             vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                 vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                               vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                               vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                               vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                              vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                              vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                              vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool2_t vm,
+                                                 vfloat8e4m3m4_t vd,
                                                  vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                             vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                             vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                             vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                            vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                            vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                            vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                vbfloat16m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                           vbfloat16m2_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                           vbfloat16m4_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                           vbfloat16m8_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vbfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vbfloat16mf2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vbfloat16m1_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                 vbfloat16m2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                 vbfloat16m4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                             vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                 vbfloat16m8_t vs2,
                                                 unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                               vbfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                               vbfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                               vbfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vbfloat16m1_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                              vbfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
                                                  vbfloat16m2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                              vbfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
                                                  vbfloat16m4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                              vbfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool2_t vm,
+                                                 vfloat8e4m3m4_t vd,
                                                  vbfloat16m8_t vs2,
                                                  unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                             vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                             vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                             vbfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                            vbfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                            vbfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                            vbfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 ----
@@ -78508,243 +78537,276 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
-                                            size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
-                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                               size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                               size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                           vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                           vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                           vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
                                                  vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
                                                  vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
                                                  vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                 vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                             vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                 vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                               vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                               vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                               vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                              vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                              vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                              vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool2_t vm,
+                                                 vfloat8e5m2m4_t vd,
                                                  vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                             vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                             vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                             vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                            vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                            vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                            vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                vbfloat16m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                           vbfloat16m2_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                           vbfloat16m4_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                           vbfloat16m8_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
                                                  vbfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
                                                  vbfloat16mf2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
                                                  vbfloat16m1_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vbfloat16m2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                 vbfloat16m4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                             vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                 vbfloat16m8_t vs2,
                                                 unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                               vbfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                               vbfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                               vbfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vbfloat16m1_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                              vbfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
                                                  vbfloat16m2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                              vbfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
                                                  vbfloat16m4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                              vbfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool2_t vm,
+                                                 vfloat8e5m2m4_t vd,
                                                  vbfloat16m8_t vs2,
                                                  unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                             vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                             vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                             vbfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                            vbfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                            vbfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                            vbfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 ----
@@ -78756,202 +78818,232 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                             vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                             vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                             vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2,
+                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2,
+                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                             vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                           vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                             vfloat32mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                             vfloat32m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                             vfloat32m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, unsigned int frm,
-                                           size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vfloat32mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vfloat32m1_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vfloat32m2_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vfloat32m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vfloat32m8_t vs2, unsigned int frm,
                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2,
+                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vfloat32mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vfloat32m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vfloat32m2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                             vfloat32m4_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                             vfloat32m8_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vfloat32mf2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vfloat32m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vfloat32m2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                           vfloat32m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                           vfloat32m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, unsigned int frm,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, unsigned int frm,
-                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 [[policy-variant-overloadedfp32-to-ofp8-e5m2-conversion-instructions]]
@@ -78959,202 +79051,232 @@ vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                             vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                             vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                             vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2,
+                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2,
+                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                             vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                           vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                             vfloat32mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                             vfloat32m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                             vfloat32m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, unsigned int frm,
-                                           size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vfloat32mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vfloat32m1_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vfloat32m2_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vfloat32m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vfloat32m8_t vs2, unsigned int frm,
                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2,
+                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vfloat32mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vfloat32m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vfloat32m2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                             vfloat32m4_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                             vfloat32m8_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vfloat32mf2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vfloat32m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vfloat32m2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                           vfloat32m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                           vfloat32m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, unsigned int frm,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, unsigned int frm,
-                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 === Zvabd - Vector Absolute Difference instructions

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/10_zvfofp8min_-_ofp8_to_bf16_conversion_instructions.adoc
@@ -6,59 +6,57 @@
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m1_t vd, vuint8mf2_t vs2,
-                                              size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m2_t vd, vuint8m1_t vs2,
-                                              size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m4_t vd, vuint8m2_t vs2,
-                                              size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tu(vbfloat16m8_t vd, vuint8m4_t vs2,
-                                              size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf4_t vd, vfloat8e4m3mf8_t vs2,
+                                        size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf2_t vd, vfloat8e4m3mf4_t vs2,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m1_t vd, vfloat8e4m3mf2_t vs2,
+                                       size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m2_t vd, vfloat8e4m3m1_t vs2,
+                                       size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m4_t vd, vfloat8e4m3m2_t vs2,
+                                       size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m8_t vd, vfloat8e4m3m4_t vs2,
+                                       size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
-                                                vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
-                                                vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
-                                               vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
-                                               vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
-                                               vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
-                                               vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
+                                         vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
+                                         vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
+                                        vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
+                                        vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
+                                        vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
+                                        vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool64_t vm,
-                                                 vbfloat16mf4_t vd,
-                                                 vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool32_t vm,
-                                                 vbfloat16mf2_t vd,
-                                                 vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
-                                                vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
-                                                vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
-                                                vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
-                                                vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tumu(vbool64_t vm, vbfloat16mf4_t vd,
+                                          vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tumu(vbool32_t vm, vbfloat16mf2_t vd,
+                                          vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
+                                         vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
+                                         vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
+                                         vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
+                                         vfloat8e4m3m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
-                                              vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
-                                              vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
-                                              vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
-                                              vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
+                                        vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
+                                        vfloat8e4m3mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
+                                       vfloat8e4m3mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
+                                       vfloat8e4m3m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
+                                       vfloat8e4m3m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
+                                       vfloat8e4m3m4_t vs2, size_t vl);
 ----
 
 [[policy-variant-overloadedofp8-e5m2-to-bf16-conversion-instructions]]
@@ -66,57 +64,55 @@ vbfloat16m8_t __riscv_vfwcvt_f_f8e4m3_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
 
 [,c]
 ----
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m1_t vd, vuint8mf2_t vs2,
-                                              size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m2_t vd, vuint8m1_t vs2,
-                                              size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m4_t vd, vuint8m2_t vs2,
-                                              size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tu(vbfloat16m8_t vd, vuint8m4_t vs2,
-                                              size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf4_t vd, vfloat8e5m2mf8_t vs2,
+                                        size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16mf2_t vd, vfloat8e5m2mf4_t vs2,
+                                        size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m1_t vd, vfloat8e5m2mf2_t vs2,
+                                       size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m2_t vd, vfloat8e5m2m1_t vs2,
+                                       size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m4_t vd, vfloat8e5m2m2_t vs2,
+                                       size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tu(vbfloat16m8_t vd, vfloat8e5m2m4_t vs2,
+                                       size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
-                                                vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
-                                                vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
-                                               vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
-                                               vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
-                                               vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
-                                               vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tum(vbool64_t vm, vbfloat16mf4_t vd,
+                                         vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tum(vbool32_t vm, vbfloat16mf2_t vd,
+                                         vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tum(vbool16_t vm, vbfloat16m1_t vd,
+                                        vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tum(vbool8_t vm, vbfloat16m2_t vd,
+                                        vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tum(vbool4_t vm, vbfloat16m4_t vd,
+                                        vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tum(vbool2_t vm, vbfloat16m8_t vd,
+                                        vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool64_t vm,
-                                                 vbfloat16mf4_t vd,
-                                                 vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool32_t vm,
-                                                 vbfloat16mf2_t vd,
-                                                 vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
-                                                vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
-                                                vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
-                                                vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
-                                                vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_tumu(vbool64_t vm, vbfloat16mf4_t vd,
+                                          vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_tumu(vbool32_t vm, vbfloat16mf2_t vd,
+                                          vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_tumu(vbool16_t vm, vbfloat16m1_t vd,
+                                         vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_tumu(vbool8_t vm, vbfloat16m2_t vd,
+                                         vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_tumu(vbool4_t vm, vbfloat16m4_t vd,
+                                         vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_tumu(vbool2_t vm, vbfloat16m8_t vd,
+                                         vfloat8e5m2m4_t vs2, size_t vl);
 // masked functions
-vbfloat16mf4_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
-                                               vuint8mf8_t vs2, size_t vl);
-vbfloat16mf2_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
-                                               vuint8mf4_t vs2, size_t vl);
-vbfloat16m1_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
-                                              vuint8mf2_t vs2, size_t vl);
-vbfloat16m2_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
-                                              vuint8m1_t vs2, size_t vl);
-vbfloat16m4_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
-                                              vuint8m2_t vs2, size_t vl);
-vbfloat16m8_t __riscv_vfwcvt_f_f8e5m2_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
-                                              vuint8m4_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16_mu(vbool64_t vm, vbfloat16mf4_t vd,
+                                        vfloat8e5m2mf8_t vs2, size_t vl);
+vbfloat16mf2_t __riscv_vfwcvt_f_bf16_mu(vbool32_t vm, vbfloat16mf2_t vd,
+                                        vfloat8e5m2mf4_t vs2, size_t vl);
+vbfloat16m1_t __riscv_vfwcvt_f_bf16_mu(vbool16_t vm, vbfloat16m1_t vd,
+                                       vfloat8e5m2mf2_t vs2, size_t vl);
+vbfloat16m2_t __riscv_vfwcvt_f_bf16_mu(vbool8_t vm, vbfloat16m2_t vd,
+                                       vfloat8e5m2m1_t vs2, size_t vl);
+vbfloat16m4_t __riscv_vfwcvt_f_bf16_mu(vbool4_t vm, vbfloat16m4_t vd,
+                                       vfloat8e5m2m2_t vs2, size_t vl);
+vbfloat16m8_t __riscv_vfwcvt_f_bf16_mu(vbool2_t vm, vbfloat16m8_t vd,
+                                       vfloat8e5m2m4_t vs2, size_t vl);
 ----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/11_zvfofp8min_-_bf16_to_ofp8_conversion_instructions.adoc
@@ -6,243 +6,276 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
-                                            size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
-                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                               size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                               size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                           vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                           vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                           vbfloat16m8_t vs2, size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                 vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                 vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                             vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                 vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                               vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                               vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                               vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                              vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                              vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                              vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool2_t vm,
+                                                 vfloat8e4m3m4_t vd,
                                                  vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                             vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                             vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                             vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                            vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                            vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                            vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                vbfloat16m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                            vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                            vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                           vbfloat16m2_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                           vbfloat16m4_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                           vbfloat16m8_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m4_t vd,
+                                               vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
                                                  vbfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
                                                  vbfloat16mf2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
                                                  vbfloat16m1_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                 vbfloat16m2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                 vbfloat16m4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                             vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                 vbfloat16m8_t vs2,
                                                 unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                               vbfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                               vbfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                               vbfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
                                                   vbfloat16m1_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                              vbfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
                                                  vbfloat16m2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                              vbfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
                                                  vbfloat16m4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                              vbfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool2_t vm,
+                                                 vfloat8e4m3m4_t vd,
                                                  vbfloat16m8_t vs2,
                                                  unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                             vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                             vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                             vbfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                            vbfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
                                                vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                            vbfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
                                                vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                            vbfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e4m3m4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool2_t vm, vfloat8e4m3m4_t vd,
                                                vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 ----
@@ -252,243 +285,276 @@ vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e4m3_mu(vbool2_t vm, vuint8m4_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
-                                            size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
-                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                               size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                               size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                               size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                           vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                           vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                           vbfloat16m8_t vs2, size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
                                                  vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
                                                  vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
                                                  vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                 vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                             vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                 vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                               vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                               vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                               vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                              vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
                                                  vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                              vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
                                                  vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                              vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool2_t vm,
+                                                 vfloat8e5m2m4_t vd,
                                                  vbfloat16m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                             vbfloat16mf4_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                             vbfloat16mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                             vbfloat16m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                            vbfloat16m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                vbfloat16m2_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                            vbfloat16m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                vbfloat16m4_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                            vbfloat16m8_t vs2, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                vbfloat16m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf8_t vd, vbfloat16mf4_t vs2,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                            vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf4_t vd, vbfloat16mf2_t vs2,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                            vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8mf2_t vd, vbfloat16m1_t vs2,
-                                            unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                            vbfloat16m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m1_t vd, vbfloat16m2_t vs2,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                           vbfloat16m2_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m2_t vd, vbfloat16m4_t vs2,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                           vbfloat16m4_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tu(vuint8m4_t vd, vbfloat16m8_t vs2,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                           vbfloat16m8_t vs2, unsigned int frm,
+                                           size_t vl);
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m4_t vd,
+                                               vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vbfloat16mf4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
                                                  vbfloat16mf4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vbfloat16mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
                                                  vbfloat16mf2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vbfloat16m1_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
                                                  vbfloat16m1_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vbfloat16m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                 vbfloat16m2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vbfloat16m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                 vbfloat16m4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                             vbfloat16m8_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tum(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                 vbfloat16m8_t vs2,
                                                 unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                               vbfloat16mf4_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
                                                   vbfloat16mf4_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                               vbfloat16mf2_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
                                                   vbfloat16mf2_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                               vbfloat16m1_t vs2,
                                               unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
                                                   vbfloat16m1_t vs2,
                                                   unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                              vbfloat16m2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
                                                  vbfloat16m2_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                              vbfloat16m4_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
                                                  vbfloat16m4_t vs2,
                                                  unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                              vbfloat16m8_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_tumu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool2_t vm,
+                                                 vfloat8e5m2m4_t vd,
                                                  vbfloat16m8_t vs2,
                                                  unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                             vbfloat16mf4_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
                                                 vbfloat16mf4_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                             vbfloat16mf2_t vs2,
                                             unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
                                                 vbfloat16mf2_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                             vbfloat16m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
                                                 vbfloat16m1_t vs2,
                                                 unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                            vbfloat16m2_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
                                                vbfloat16m2_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                            vbfloat16m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
                                                vbfloat16m4_t vs2,
                                                unsigned int frm, size_t vl);
-vuint8m4_t __riscv_vfncvt_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                            vbfloat16m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8m4_t __riscv_vfncvt_sat_f_bf16_f8e5m2_mu(vbool2_t vm, vuint8m4_t vd,
+vfloat8e5m2m4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool2_t vm, vfloat8e5m2m4_t vd,
                                                vbfloat16m8_t vs2,
                                                unsigned int frm, size_t vl);
 ----

--- a/auto-generated/policy_funcs/overloaded_intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
+++ b/auto-generated/policy_funcs/overloaded_intrinsic_funcs/12_zvfofp8min_-_fp32_to_ofp8_conversion_instructions.adoc
@@ -6,202 +6,232 @@
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                             vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                             vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                             vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2,
+                                           size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2,
+                                           size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                             vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                           vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
                                             vfloat32mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
                                             vfloat32m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
                                             vfloat32m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, unsigned int frm,
-                                           size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m1_t vd, vfloat32m4_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tu(vfloat8e4m3m2_t vd, vfloat32m8_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tu(vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tum(vbool64_t vm, vfloat8e4m3mf8_t vd,
                                              vfloat32mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool64_t vm,
+                                                 vfloat8e4m3mf8_t vd,
+                                                 vfloat32mf2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tum(vbool32_t vm, vfloat8e4m3mf4_t vd,
                                              vfloat32m1_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool32_t vm,
+                                                 vfloat8e4m3mf4_t vd,
+                                                 vfloat32m1_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tum(vbool16_t vm, vfloat8e4m3mf2_t vd,
                                              vfloat32m2_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool16_t vm,
+                                                 vfloat8e4m3mf2_t vd,
+                                                 vfloat32m2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
                                             vfloat32m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                                vfloat32m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
                                             vfloat32m8_t vs2, unsigned int frm,
                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tum(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                                vfloat32m8_t vs2,
+                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_tumu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                              vfloat32mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool64_t vm,
+                                                  vfloat8e4m3mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_tumu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                              vfloat32m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool32_t vm,
+                                                  vfloat8e4m3mf4_t vd,
+                                                  vfloat32m1_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                              vfloat32m2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool16_t vm,
+                                                  vfloat8e4m3mf2_t vd,
+                                                  vfloat32m2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_tumu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                             vfloat32m4_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool8_t vm,
+                                                 vfloat8e4m3m1_t vd,
+                                                 vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_tumu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                             vfloat32m8_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_tumu(vbool4_t vm,
+                                                 vfloat8e4m3m2_t vd,
+                                                 vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+// masked functions
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3_mu(vbool64_t vm, vfloat8e4m3mf8_t vd,
+                                            vfloat32mf2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool64_t vm,
+                                                vfloat8e4m3mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vfloat8e4m3mf4_t vd,
+                                            vfloat32m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm,
+                                                vfloat8e4m3mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vfloat8e4m3mf2_t vd,
+                                            vfloat32m2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e4m3mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm,
+                                                vfloat8e4m3mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e4m3m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                           vfloat32m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, unsigned int frm,
+vfloat8e4m3m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vfloat8e4m3m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                           vfloat32m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, unsigned int frm,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, unsigned int frm,
-                                          size_t vl);
+vfloat8e4m3m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vfloat8e4m3m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----
 
 [[policy-variant-overloadedfp32-to-ofp8-e5m2-conversion-instructions]]
@@ -209,200 +239,230 @@ vuint8m2_t __riscv_vfncvt_sat_f_f8e4m3_mu(vbool4_t vm, vuint8m2_t vd,
 
 [,c]
 ----
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          size_t vl);
-// masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                             vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                             vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                             vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2,
+                                           size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2,
+                                           size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, size_t vl);
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf8_t vd, vfloat32mf2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf4_t vd, vfloat32m1_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                       unsigned int frm, size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8mf2_t vd, vfloat32m2_t vs2,
-                                           unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m1_t vd, vfloat32m4_t vs2,
-                                          unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                      unsigned int frm, size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vuint8m2_t vd, vfloat32m8_t vs2,
-                                          unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                             vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                             vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
-                                        vfloat32mf2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                           vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                           vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
                                             vfloat32mf2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
-                                        vfloat32m1_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
                                             vfloat32m1_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
-                                        vfloat32m2_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
                                             vfloat32m2_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                       vfloat32m4_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vuint8m1_t vd,
-                                           vfloat32m4_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                       vfloat32m8_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vuint8m2_t vd,
-                                           vfloat32m8_t vs2, unsigned int frm,
-                                           size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m1_t vd, vfloat32m4_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tu(vfloat8e5m2m2_t vd, vfloat32m8_t vs2,
+                                           unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tu(vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
-                                         vfloat32mf2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm, vuint8mf8_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tum(vbool64_t vm, vfloat8e5m2mf8_t vd,
                                              vfloat32mf2_t vs2,
                                              unsigned int frm, size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
-                                         vfloat32m1_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm, vuint8mf4_t vd,
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool64_t vm,
+                                                 vfloat8e5m2mf8_t vd,
+                                                 vfloat32mf2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tum(vbool32_t vm, vfloat8e5m2mf4_t vd,
                                              vfloat32m1_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
-                                         vfloat32m2_t vs2, unsigned int frm,
-                                         size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm, vuint8mf2_t vd,
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool32_t vm,
+                                                 vfloat8e5m2mf4_t vd,
+                                                 vfloat32m1_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tum(vbool16_t vm, vfloat8e5m2mf2_t vd,
                                              vfloat32m2_t vs2, unsigned int frm,
                                              size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
-                                        vfloat32m4_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm, vuint8m1_t vd,
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool16_t vm,
+                                                 vfloat8e5m2mf2_t vd,
+                                                 vfloat32m2_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
                                             vfloat32m4_t vs2, unsigned int frm,
                                             size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
-                                        vfloat32m8_t vs2, unsigned int frm,
-                                        size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm, vuint8m2_t vd,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                                vfloat32m4_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
                                             vfloat32m8_t vs2, unsigned int frm,
                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tum(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                                vfloat32m8_t vs2,
+                                                unsigned int frm, size_t vl);
 // masked functions
-vuint8mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                       vfloat32mf2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm, vuint8mf8_t vd,
-                                           vfloat32mf2_t vs2, unsigned int frm,
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_tumu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                              vfloat32mf2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool64_t vm,
+                                                  vfloat8e5m2mf8_t vd,
+                                                  vfloat32mf2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_tumu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                              vfloat32m1_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool32_t vm,
+                                                  vfloat8e5m2mf4_t vd,
+                                                  vfloat32m1_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                              vfloat32m2_t vs2,
+                                              unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool16_t vm,
+                                                  vfloat8e5m2mf2_t vd,
+                                                  vfloat32m2_t vs2,
+                                                  unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_tumu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                             vfloat32m4_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool8_t vm,
+                                                 vfloat8e5m2m1_t vd,
+                                                 vfloat32m4_t vs2,
+                                                 unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_tumu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                             vfloat32m8_t vs2, unsigned int frm,
+                                             size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_tumu(vbool4_t vm,
+                                                 vfloat8e5m2m2_t vd,
+                                                 vfloat32m8_t vs2,
+                                                 unsigned int frm, size_t vl);
+// masked functions
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2_mu(vbool64_t vm, vfloat8e5m2mf8_t vd,
+                                            vfloat32mf2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool64_t vm,
+                                                vfloat8e5m2mf8_t vd,
+                                                vfloat32mf2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vfloat8e5m2mf4_t vd,
+                                            vfloat32m1_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm,
+                                                vfloat8e5m2mf4_t vd,
+                                                vfloat32m1_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vfloat8e5m2mf2_t vd,
+                                            vfloat32m2_t vs2, unsigned int frm,
+                                            size_t vl);
+vfloat8e5m2mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm,
+                                                vfloat8e5m2mf2_t vd,
+                                                vfloat32m2_t vs2,
+                                                unsigned int frm, size_t vl);
+vfloat8e5m2m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                           vfloat32m4_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf4_t __riscv_vfncvt_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                       vfloat32m1_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf4_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool32_t vm, vuint8mf4_t vd,
-                                           vfloat32m1_t vs2, unsigned int frm,
+vfloat8e5m2m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vfloat8e5m2m1_t vd,
+                                               vfloat32m4_t vs2,
+                                               unsigned int frm, size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                           vfloat32m8_t vs2, unsigned int frm,
                                            size_t vl);
-vuint8mf2_t __riscv_vfncvt_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                       vfloat32m2_t vs2, unsigned int frm,
-                                       size_t vl);
-vuint8mf2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool16_t vm, vuint8mf2_t vd,
-                                           vfloat32m2_t vs2, unsigned int frm,
-                                           size_t vl);
-vuint8m1_t __riscv_vfncvt_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                      vfloat32m4_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m1_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool8_t vm, vuint8m1_t vd,
-                                          vfloat32m4_t vs2, unsigned int frm,
-                                          size_t vl);
-vuint8m2_t __riscv_vfncvt_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                      vfloat32m8_t vs2, unsigned int frm,
-                                      size_t vl);
-vuint8m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vuint8m2_t vd,
-                                          vfloat32m8_t vs2, unsigned int frm,
-                                          size_t vl);
+vfloat8e5m2m2_t __riscv_vfncvt_sat_f_f8e5m2_mu(vbool4_t vm, vfloat8e5m2m2_t vd,
+                                               vfloat32m8_t vs2,
+                                               unsigned int frm, size_t vl);
 ----

--- a/doc/rvv-intrinsic-spec.adoc
+++ b/doc/rvv-intrinsic-spec.adoc
@@ -347,6 +347,22 @@ vint8mf8_t __riscv_vfncvt_rtz_x_f_w_bf16mf4_i8mf8(vbfloat16mf4_t vs2, size_t vl)
 vuint16mf4_t __riscv_vfclass_v_bf16mf4_u16mf4(vbfloat16mf4_t vs2, size_t vl);
 ----
 
+==== Vector Widening OFP8 to BF16 Type-Convert instruction
+[,c]
+----
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e4m3mf8_bf16mf4(vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_f_v_f8e5m2mf8_bf16mf4(vfloat8e5m2mf8_t vs2, size_t vl);
+----
+
+==== Vector Narrowing BF16 to OFP8 Type-Convert instruction
+[,c]
+----
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e4m3mf8(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f_w_bf16mf4_f8e5m2mf8(vbfloat16mf4_t vs2, size_t vl);
+----
+
 [[implicit-naming-scheme]]
 === Implicit (Overloaded) naming scheme
 
@@ -431,6 +447,24 @@ Add `_bf16` suffix to disambiguate between `zvfhmin` instructions, e.g. `vfloat1
 ----
 vbfloat16mf4_t __riscv_vfncvt_f_bf16(vfloat32mf2_t vs2, size_t vl);
 vbfloat16mf4_t __riscv_vfncvt_rod_f_bf16(vfloat32mf2_t vs2, size_t vl);
+----
+
+==== Widening OFP8 to BF16 Type-Convert instructions
+
+[,c]
+----
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e4m3mf8_t vs2, size_t vl);
+vbfloat16mf4_t __riscv_vfwcvt_f_bf16(vfloat8e5m2mf8_t vs2, size_t vl);
+----
+
+==== Narrowing BF16/FP32 to OFP8 Type-Convert instructions
+
+[,c]
+----
+vfloat8e4m3mf8_t __riscv_vfncvt_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e4m3mf8_t __riscv_vfncvt_sat_f_f8e4m3(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
+vfloat8e5m2mf8_t __riscv_vfncvt_sat_f_f8e5m2(vbfloat16mf4_t vs2, size_t vl);
 ----
 
 ==== Type-convert instructions
@@ -526,6 +560,8 @@ Types with an asterisk ({empty}*) are available when `ELEN >= 64` (that is, unav
 | _Float16 | N/A | vfloat16mf4_t^*^ | vfloat16mf2_t | vfloat16m1_t | vfloat16m2_t | vfloat16m4_t | vfloat16m8_t
 | float | N/A | N/A | vfloat32mf2_t^*^ | vfloat32m1_t | vfloat32m2_t | vfloat32m4_t | vfloat32m8_t
 | double | N/A | N/A | N/A | vfloat64m1_t | vfloat64m2_t | vfloat64m4_t | vfloat64m8_t
+| float8e4m3 | vfloat8e4m3mf8_t^*^ | vfloat8e4m3mf4_t | vfloat8e4m3mf2_t | vfloat8e4m3m1_t | vfloat8e4m3m2_t | vfloat8e4m3m4_t | vfloat8e4m3m8_t
+| float8e5m2 | vfloat8e5m2mf8_t^*^ | vfloat8e5m2mf4_t | vfloat8e5m2mf2_t | vfloat8e5m2m1_t | vfloat8e5m2m2_t | vfloat8e5m2m4_t | vfloat8e5m2m8_t
 |===
 
 === Mask types

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/generator.py
@@ -268,24 +268,14 @@ class Generator(ABC):
         overloaded_name = "_".join(sn[0:2])
         if "cvt_sat_f_f_q" in name or "ncvt_sat_f_f_w" in name:
           overloaded_name = "_".join(sn[0:3])
-        e4m3 = name.find("f8e4m3")
-        e5m2 = name.find("f8e5m2")
-        bf16 = name.find("bf16")
-        if e4m3 != -1 and bf16 != -1:
-          if e4m3 < bf16:
-            overloaded_name += "_f8e4m3_bf16"
+        if "f8e4m3" in name or "f8e5m2" in name:
+          if "wcvt" in name:
+            overloaded_name += "_bf16"
+          elif "f8e4m3" in name:
+            overloaded_name += "_f8e4m3"
           else:
-            overloaded_name += "_bf16_f8e4m3"
-        elif e5m2 != -1 and bf16 != -1:
-          if e5m2 < bf16:
-            overloaded_name += "_f8e5m2_bf16"
-          else:
-            overloaded_name += "_bf16_f8e5m2"
-        elif e4m3 != -1:
-          overloaded_name += "_f8e4m3"
-        elif e5m2 != -1:
-          overloaded_name += "_f8e5m2"
-        elif bf16 != -1 and "wcvt" not in name:
+            overloaded_name += "_f8e5m2"
+        elif "bf16" in name and "wcvt" not in name:
           overloaded_name += "_bf16"
       else:
         overloaded_name = "_".join(sn[0:2])

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/inst.py
@@ -545,13 +545,13 @@ def gen(g):
   g.function_group(zvfofp8min_template,
                    "OFP8(E4M3) to BF16 conversion instructions",
                    "ofp8-e4m3-to-bf16-conversion-instructions", ["wcvtbf16"],
-                   ["f8e4m3"], [8], WLMULS,
+                   ["float8e4m3"], [8], WLMULS,
                    decorators.has_masking_maskedoff_policy,
                    required_ext_list=["zvfofp8min"])
   g.function_group(zvfofp8min_template,
                    "OFP8(E5M2) to BF16 conversion instructions",
                    "ofp8-e5m2-to-bf16-conversion-instructions", ["wcvtbf16"],
-                   ["f8e5m2"], [8], WLMULS,
+                   ["float8e5m2"], [8], WLMULS,
                    decorators.has_masking_maskedoff_policy,
                    required_ext_list=["zvfofp8min"])
 
@@ -559,13 +559,13 @@ def gen(g):
   g.function_group(zvfofp8min_template,
                    "BF16 to OFP8(E4M3) conversion instructions",
                    "bf16-to-ofp8-e4m3-conversion-instructions", ["ncvtbf16"],
-                   ["f8e4m3"], [16], NCVTLMULS,
+                   ["float8e4m3"], [16], NCVTLMULS,
                    decorators.has_masking_maskedoff_policy_frm,
                    required_ext_list=["zvfofp8min"])
   g.function_group(zvfofp8min_template,
                    "BF16 to OFP8(E5M2) conversion instructions",
                    "bf16-to-ofp8-e5m2-conversion-instructions", ["ncvtbf16"],
-                   ["f8e5m2"], [16], NCVTLMULS,
+                   ["float8e5m2"], [16], NCVTLMULS,
                    decorators.has_masking_maskedoff_policy_frm,
                    required_ext_list=["zvfofp8min"])
 
@@ -573,13 +573,13 @@ def gen(g):
   g.function_group(zvfofp8min_template,
                    "FP32 to OFP8(E4M3) conversion instructions",
                    "fp32-to-ofp8-e4m3-conversion-instructions", ["ncvt"],
-                   ["f8e4m3"], [32], NCVTLMULS,
+                   ["float8e4m3"], [32], NCVTLMULS,
                    decorators.has_masking_maskedoff_policy_frm,
                    required_ext_list=["zvfofp8min"])
   g.function_group(zvfofp8min_template,
                    "FP32 to OFP8(E5M2) conversion instructions",
                    "fp32-to-ofp8-e5m2-conversion-instructions", ["ncvt"],
-                   ["f8e5m2"], [32], NCVTLMULS,
+                   ["float8e5m2"], [32], NCVTLMULS,
                    decorators.has_masking_maskedoff_policy_frm,
                    required_ext_list=["zvfofp8min"])
   ####################################################################

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/zvfofp8min_template.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/templates/zvfofp8min_template.py
@@ -44,11 +44,11 @@ def render(G,
     # Variable in list means
     # [dst_type, dst_type_short, src_type, src_type_short]
     if "ncvtbf16" in op_list:
-      convert_set = [["uint", "xu", "bfloat", "bf"]]
+      convert_set = [[type_list[0], "xu", "bfloat", "bf"]]
     elif "ncvt" in op_list:
-      convert_set = [["uint", "xu", "float", "f"]]
+      convert_set = [[type_list[0], "xu", "float", "f"]]
     elif "wcvtbf16" in op_list:
-      convert_set = [["bfloat", "bf", "uint", "xu"]]
+      convert_set = [["bfloat", "bf", type_list[0], "xu"]]
     else:
       assert False, "Unhandled instruction with type_list = 'bfloat16'"
     for args in prod(
@@ -95,7 +95,7 @@ def render(G,
          not type_helper.valid_vtype(src_type):
         continue
 
-      args["F8TYPE"] = type_list[0]
+      args["F8TYPE"] = type_list[0].replace("float8", "f8")
       args["OP_REPLACED"] = args["OP"].replace("bf16", "")
       if "ncvtbf16" in args["OP"]:
         func_name = "{OP_REPLACED}_f_f_w_bf16m{ORIG_LMUL}_{F8TYPE}m{LLMUL}".format_map(

--- a/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
+++ b/rvv-intrinsic-generator/rvv_intrinsic_gen/utils.py
@@ -91,14 +91,16 @@ class TypeHelper:
       return f"vbool{int(self.args['SEW'] / self.get_float_lmul)}_t"
 
   def valid_vtype(self, vtype):
-    p = "v(bool|int|uint|float|bfloat)(?P<SEW>[0-9]+)m(?P<LMUL>f?[0-9])_t"
+    p = "v(bool|int|uint|float8e4m3|float8e5m2|float|bfloat)(?P<SEW>[0-9]*)m(?P<LMUL>f?[0-9])_t"
     i = re.match(p, vtype)
     if i is None:
       return False
     sew = i.group("SEW")
     lmul = i.group("LMUL")
     # assume ELEN = 64
-    if vtype[:6] == "vfloat":
+    if vtype[:8] == "vfloat8e":
+      sew = "8"
+    elif vtype[:6] == "vfloat":
       if sew not in ["16", "32", "64"]:
         return False
     elif vtype[:7] == "vbfloat":
@@ -115,6 +117,8 @@ class TypeHelper:
 
   @property
   def v(self):
+    if self.args.get("TYPE", "").startswith("float8e"):
+      return "v{TYPE}m{LMUL}_t".format_map(self.args)
     return "v{TYPE}{SEW}m{LMUL}_t".format_map(self.args)
 
   @property
@@ -123,6 +127,8 @@ class TypeHelper:
 
   @property
   def vm1(self):
+    if self.args.get("TYPE", "").startswith("float8e"):
+      return "v{TYPE}m1_t".format_map(self.args)
     return "v{TYPE}{SEW}m1_t".format_map(self.args)
 
   @property


### PR DESCRIPTION
Upstream llvm is going to support OFP8 RVV types: https://github.com/llvm/llvm-project/pull/191349
This patch:
1. Change uint8 argument type to float8e4m3/float8e5m2
2. Change vfncvt overloaded intrinsic from: vfncvt_f_bf16_f8e4m3 -> vfncvt_f_f8e4m3
3. Change vfwcvt overloaded intrinsic from: vfwcvt_f_f8e4m3_bf16 -> vfncvt_f_bf16
4. Update ofp8 rules to spec.adoc